### PR TITLE
fix: Restore the container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
+# The bookworm tags are frozen at an old uv whose newest 3.14 cannot satisfy
+# requires-python, so this follows trixie instead.
+FROM ghcr.io/astral-sh/uv:0.12.6-python3.14-trixie-slim
 
 WORKDIR /app
 
 # Railway streams stdout; without this the logs arrive in block-sized bursts.
 ENV PYTHONUNBUFFERED=1
 
-# Install system utilities needed for loclx
-RUN apt-get update && apt-get install -y --no-install-recommends curl unzip && \
-    curl -s https://loclx.io/dl/loclx-linux-amd64.zip -o loclx.zip && \
-    unzip loclx.zip -d /usr/local/bin/ && \
-    chmod +x /usr/local/bin/loclx && \
-    rm loclx.zip && \
-    rm -rf /var/lib/apt/lists/*
+# Otherwise uv downloads the newest interpreter satisfying requires-python,
+# which can be a pre-release with no wheels for the compiled dependencies.
+ENV UV_PYTHON_PREFERENCE=only-system
 
-# Install Python dependencies using uv
+# The official image ships loclx statically linked, so this needs no apt-get.
+COPY --from=localxpose/localxpose:latest /ko-app/loclx /usr/local/bin/loclx
+
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project
 
-# Copy project files (including alembic configs, seed.py, and parquet files if committed)
 COPY . .
-
-# Grant execute permissions to the startup script
 RUN chmod +x start.sh
 
 CMD ["/app/start.sh"]


### PR DESCRIPTION
loclx.io no longer resolves, so fetching the zip failed with curl exit 6. The official image ships loclx statically linked, so copy it from there and drop the apt-get, curl and unzip layer with it.

Behind that failure, uv sync could not install either: the bookworm uv tags are frozen at 0.9.30, whose newest 3.14 is 3.14.2 and so cannot satisfy requires-python. uv fell back to a 3.15 pre-release, which has no httptools wheel and no compiler in the slim image to build one. Follow the trixie tag that ships 3.14.7 and confine interpreter selection to the image's own Python.