### PR TITLE
refactor: Collapse error reporting into one module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,10 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
 - **Everything the bot says about itself goes through `errors.py`.** `report(exc,
   context)` for an exception, `notify(text)` for anything else worth the admin
   channel. Neither raises, both log locally first, and both say so when the channel
-  is out of reach. Nothing else may resolve `config.channel("bot_admin")`.
+  is out of reach. The one other resolver of `config.channel("bot_admin")` is the
+  startup announcement in `init/bot_init.py`, which sends directly because it marks
+  itself done only once the send lands, so a missed announcement retries on the next
+  reconnect.
 - **Text from the database is formatted with `safe_format`**, never bare `str.format`
   — a row is not source, and one unmatched brace should not lose the whole message.
   `config.render` additionally resolves `{channel:key}` and `{role:key}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,8 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
 - **Everything the bot says about itself goes through `errors.py`.** `report(exc,
   context)` for an exception, `notify(text)` for anything else worth the admin
   channel. Neither raises, both log locally first, and both say so when the channel
-  is out of reach. The one other resolver of `config.channel("bot_admin")` is the
-  startup announcement in `init/bot_init.py`, which sends directly because it marks
-  itself done only once the send lands, so a missed announcement retries on the next
-  reconnect.
+  is out of reach. `notify` returns whether it landed, for the one caller that
+  retries. Nothing else may resolve `config.channel("bot_admin")`.
 - **Text from the database is formatted with `safe_format`**, never bare `str.format`
   — a row is not source, and one unmatched brace should not lose the whole message.
   `config.render` additionally resolves `{channel:key}` and `{role:key}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,10 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
   `init/bot_init.py` and `views/` import services lazily to break cycles. Leave them.
 - **`token_manager` and `shoutout_queue` are singletons** (`__new__`). Import the
   instance; do not construct another.
-- **Errors surface in Discord**, to `config.channel("bot_admin")`, with the traceback
-  attached as a file. Follow the existing `get_error_details` / `handle_error` pattern
-  rather than only logging.
+- **Everything the bot says about itself goes through `errors.py`.** `report(exc,
+  context)` for an exception, `notify(text)` for anything else worth the admin
+  channel. Neither raises, both log locally first, and both say so when the channel
+  is out of reach. Nothing else may resolve `config.channel("bot_admin")`.
 - **Text from the database is formatted with `safe_format`**, never bare `str.format`
   — a row is not source, and one unmatched brace should not lose the whole message.
   `config.render` additionally resolves `{channel:key}` and `{role:key}`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,79 @@
+# Valin Malach Bot
+
+One process serving two faces: a Discord bot and a FastAPI app that receives
+Twitch EventSub webhooks. This file fixes the words used for the concepts that
+span both, so a term means one thing wherever it appears.
+
+## Language
+
+### Admin surface
+
+How the bot talks about itself, as opposed to what it says to viewers.
+
+**Admin channel**:
+The one Discord channel the bot uses to report on its own health, resolved by
+the slug `bot_admin`. Not a place viewers see.
+_Avoid_: error channel, log channel, bot_admin (in prose)
+
+**Report**:
+An exception delivered to the **admin channel**, with its traceback attached as
+a file. Reporting never raises and never blocks the path that failed.
+_Avoid_: error log, handled error, error report
+
+**Notice**:
+A message to the **admin channel** that is not an exception — a rejected webhook
+signature, a revoked EventSub subscription, an unavailable token.
+_Avoid_: warning, alert (see flagged ambiguities), admin message
+
+### Twitch stream lifecycle
+
+**Live alert**:
+The Discord message announcing that a stream is live, kept up to date while it
+runs and rewritten once when it ends. One row in `live_alert` per broadcaster.
+_Avoid_: stream notification, go-live post, announcement
+
+**Shoutout queue**:
+The pending `!so` targets, drained at a rate Helix accepts. Active only while
+the broadcaster is live.
+_Avoid_: shoutout list, so queue
+
+## Flagged ambiguities
+
+**`log_error` names two different behaviours.** Four files define it as
+"upload the traceback to the admin channel"; `main.py` defines it as "write to
+the local logger and stop". Resolved: **report** is the only name for reaching
+the admin channel. Local logging is not a separate concept — every report logs
+locally first, and says so when it cannot go further.
+
+**"Alert" means the live alert, never an admin notice.** An admin-channel
+message about a failure is a **notice** or a **report**. Nothing else in this
+project is called an alert.
+
+**Two functions named `_create_offline_embed`** exist, in `controller/twitch.py`
+and `services/twitch/api.py`, and both close a **live alert**. Unresolved — the
+duplication is real, not just a naming collision.
+
+## Example dialogue
+
+> **Dev**: When a stream ends, who rewrites the message?
+>
+> **Operator**: Whoever notices first. The webhook usually, but the poller
+> catches it if Twitch never calls.
+>
+> **Dev**: So the live alert has two closers.
+>
+> **Operator**: Right, and if they both go it looks the same to me, so I
+> wouldn't know.
+>
+> **Dev**: You'd know if it failed — that would be a report in the admin
+> channel, with the traceback.
+>
+> **Operator**: Only if the bot is up far enough to post. Otherwise?
+>
+> **Dev**: It logs locally, then logs that it couldn't reach you. You lose the
+> report, but not silently.
+>
+> **Operator**: And the 403s I see when Twitch signatures don't match?
+>
+> **Dev**: Those aren't exceptions, so they're notices. Same channel, no
+> traceback.

--- a/cogs/birthday.py
+++ b/cogs/birthday.py
@@ -9,8 +9,8 @@ from pendulum import DateTime
 
 from constants import MAX_DAYS, Months
 from db import repository
-from errors import report
-from services import get_next_leap, send_message
+from errors import notify, report
+from services import get_next_leap
 from services.config import config, has_configured_role
 
 logger = logging.getLogger(__name__)
@@ -177,9 +177,8 @@ class Birthday(GroupCog):
         try:
             existing_user = await repository.get_user(interaction.user.id)
             if existing_user is None:
-                await send_message(
-                    f"User {interaction.user.name} ({interaction.user.id}) attempted to remove a birthday but had no record.",
-                    config.channel("bot_admin"),
+                await notify(
+                    f"User {interaction.user.name} ({interaction.user.id}) attempted to remove a birthday but had no record."
                 )
                 await interaction.response.send_message(
                     config.template("birthday_remove_failed")

--- a/cogs/birthday.py
+++ b/cogs/birthday.py
@@ -1,17 +1,15 @@
-import io
 import logging
-import traceback
 from typing import Any, Literal
 
-import discord
 import pendulum
 from discord import Interaction, Member, User, app_commands
 from discord.app_commands import Choice, Range
 from discord.ext.commands import Bot, GroupCog
 from pendulum import DateTime
 
-from constants import MAX_DAYS, ErrorDetails, Months
+from constants import MAX_DAYS, Months
 from db import repository
+from errors import report
 from services import get_next_leap, send_message
 from services.config import config, has_configured_role
 
@@ -155,17 +153,7 @@ class Birthday(GroupCog):
         self, interaction: Interaction, e: Exception
     ) -> None:
         """Handle exceptions that occur during birthday setting."""
-        error_details: ErrorDetails = {
-            "type": type(e).__name__,
-            "message": str(e),
-            "args": e.args,
-            "traceback": traceback.format_exc(),
-        }
-        error_msg = f"Exception in set_birthday for user={interaction.user.id} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-        logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-        await self._birthday_operation_failed(
-            interaction, error_msg, "set", error_details["traceback"]
-        )
+        await self._birthday_operation_failed(interaction, e, "set")
 
     @set_birthday.autocomplete("timezone")
     async def timezone_autocomplete(
@@ -214,24 +202,13 @@ class Birthday(GroupCog):
                 config.template("birthday_none_to_remove")
             )
         except Exception as e:  # noqa: BLE001
-            error_details: ErrorDetails = {
-                "type": type(e).__name__,
-                "message": str(e),
-                "args": e.args,
-                "traceback": traceback.format_exc(),
-            }
-            error_msg = f"Exception in remove_birthday for user={interaction.user.id}: {error_details['message']}"
-            logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-            await self._birthday_operation_failed(
-                interaction, error_msg, "forget", error_details["traceback"]
-            )
+            await self._birthday_operation_failed(interaction, e, "forget")
 
     async def _birthday_operation_failed(
         self,
         interaction: Interaction,
-        error_msg: str,
+        e: Exception,
         set_forget: Literal["set", "forget"],
-        traceback_str: str,
     ) -> None:
         mention = (
             interaction.guild.owner.mention
@@ -243,12 +220,10 @@ class Birthday(GroupCog):
                 "birthday_operation_failed", action=set_forget, mention=mention
             )
         )
-        traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-        traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-        await send_message(
-            f"Failed to {set_forget} birthday for {interaction.user.name}: {error_msg}",
-            config.channel("bot_admin"),
-            file=traceback_file,
+        await report(
+            e,
+            f"Failed to {set_forget} birthday for {interaction.user.name} "
+            f"(ID: {interaction.user.id})",
         )
 
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,6 +1,4 @@
-import io
 import logging
-import traceback
 from typing import Literal
 
 import discord
@@ -29,8 +27,9 @@ from discord.abc import PrivateChannel
 from discord.ext.commands import Bot, Cog, CommandError, Context
 from pendulum import DateTime
 
-from constants import DEFAULT_MISSING_CONTENT, UNKNOWN_USER, ErrorDetails
+from constants import DEFAULT_MISSING_CONTENT, UNKNOWN_USER
 from db import repository
+from errors import report
 from services import (
     get_age,
     get_channel_mention,
@@ -49,32 +48,12 @@ class Events(Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
-    def _create_error_details(self, exception: Exception) -> ErrorDetails:
-        """Create standardized error details dictionary from an exception."""
-        return {
-            "type": type(exception).__name__,
-            "message": str(exception),
-            "args": exception.args,
-            "traceback": traceback.format_exc(),
-        }
-
-    async def _handle_error(
-        self, exception: Exception, context: str, should_raise: bool = False
-    ) -> None:
-        """Centralized error handling and logging."""
-        error_details = self._create_error_details(exception)
-        error_msg = f"{context} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-        logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-        await self._send_error_message(error_msg, error_details["traceback"])
-        if should_raise:
-            raise exception
-
     async def _safe_db_operation(self, operation: str, func, *args, **kwargs) -> None:
         """Run a database write, reporting failures instead of raising."""
         try:
             await func(*args, **kwargs)
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, f"Failed to {operation}")
+            await report(e, f"Failed to {operation}")
 
     def _base_embed(self, description: str, color: int) -> Embed:
         """Create a base embed with common settings (description, color, timestamp)."""
@@ -112,19 +91,6 @@ class Events(Cog):
             [attachment.url for attachment in message.attachments],
         )
 
-    async def _send_error_message(
-        self,
-        error_msg: str,
-        traceback_str: str,
-    ) -> None:
-        traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-        traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-        await send_message(
-            error_msg,
-            config.channel("bot_admin"),
-            file=traceback_file,
-        )
-
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
         try:
@@ -137,7 +103,7 @@ class Events(Cog):
             if reply is not None:
                 await message.channel.send(reply)
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_message event")
+            await report(e, "Fatal error with on_message event")
 
     @Cog.listener()
     async def on_member_join(self, member: Member) -> None:
@@ -181,7 +147,7 @@ class Events(Cog):
                 member.name,
             )
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_member_join event")
+            await report(e, "Fatal error with on_member_join event")
 
     async def _get_user_data(self, user: User | Member) -> tuple[str, str]:
         return get_discriminator(user), get_pfp(user)
@@ -227,7 +193,7 @@ class Events(Cog):
                 member.id,
             )
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_raw_member_remove event")
+            await report(e, "Fatal error with on_raw_member_remove event")
 
     @Cog.listener()
     async def on_command_error(self, ctx: Context, error: CommandError) -> None:
@@ -245,7 +211,7 @@ class Events(Cog):
             await self._handle_nickname_change(before, after, discriminator, url)
             await self._handle_timeout_changes(before, after, discriminator, url)
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_member_update event")
+            await report(e, "Fatal error with on_member_update event")
 
     async def _handle_pfp_change(
         self, before: Member, after: Member, discriminator: str, url: str
@@ -373,7 +339,7 @@ class Events(Cog):
             await self._store_message(after)
 
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_raw_message_edit event")
+            await report(e, "Fatal error with on_raw_message_edit event")
 
     @Cog.listener()
     async def on_raw_message_delete(self, payload: RawMessageDeleteEvent) -> None:
@@ -409,7 +375,7 @@ class Events(Cog):
                 payload.message_id,
             )
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_raw_message_delete event")
+            await report(e, "Fatal error with on_raw_message_delete event")
 
     @Cog.listener()
     async def on_raw_bulk_message_delete(
@@ -444,9 +410,7 @@ class Events(Cog):
                     message_id,
                 )
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(
-                e, "Fatal error with on_raw_bulk_message_delete event"
-            )
+            await report(e, "Fatal error with on_raw_bulk_message_delete event")
 
     async def _log_ban_unban(
         self, user: User | Member, action: Literal["ban", "unban"]
@@ -467,14 +431,14 @@ class Events(Cog):
         try:
             await self._log_ban_unban(user, "ban")
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_member_ban event")
+            await report(e, "Fatal error with on_member_ban event")
 
     @Cog.listener()
     async def on_member_unban(self, guild: Guild, user: User | Member) -> None:
         try:
             await self._log_ban_unban(user, "unban")
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_member_unban event")
+            await report(e, "Fatal error with on_member_unban event")
 
     @Cog.listener()
     async def on_invite_create(self, invite: Invite) -> None:
@@ -494,7 +458,7 @@ class Events(Cog):
             embed = embed.set_author(name=f"{guild_name}", icon_url=guild_icon)
             await send_embed(embed, config.channel("audit_logs"))
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_invite_create event")
+            await report(e, "Fatal error with on_invite_create event")
 
     @Cog.listener()
     async def on_invite_delete(self, invite: Invite) -> None:
@@ -507,7 +471,7 @@ class Events(Cog):
             embed = embed.set_author(name=f"{guild_name}", icon_url=guild_icon)
             await send_embed(embed, config.channel("audit_logs"))
         except Exception as e:  # noqa: BLE001
-            await self._handle_error(e, "Fatal error with on_invite_delete event")
+            await report(e, "Fatal error with on_invite_delete event")
 
     async def _get_message_content(self, message_id: int) -> str:
         stored = await repository.get_message(message_id)

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -1,16 +1,13 @@
-import io
 import logging
-import traceback
 from datetime import datetime
 from typing import ClassVar
 
-import discord
 import pendulum
 from discord.ext import tasks
 from discord.ext.commands import Bot, Cog
 
-from constants import ErrorDetails
 from db import DiscordUser, repository
+from errors import notify, report
 from services import next_birthday, send_message
 from services.config import config
 
@@ -34,23 +31,6 @@ class Tasks(Cog):
         pendulum.Time(hour, minute) for hour in range(24) for minute in (0, 15, 30, 45)
     ]
 
-    async def log_error(self, message: str, traceback_str: str) -> None:
-        traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-        traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-        await send_message(message, config.channel("bot_admin"), file=traceback_file)
-
-    async def _handle_fatal_error(self, e: Exception, context: str) -> None:
-        """Handle fatal errors with consistent logging and notification."""
-        error_details: ErrorDetails = {
-            "type": type(e).__name__,
-            "message": str(e),
-            "args": e.args,
-            "traceback": traceback.format_exc(),
-        }
-        error_msg = f"{context} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-        logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-        await self.log_error(error_msg, error_details["traceback"])
-
     @tasks.loop(time=_quarter_hours)
     async def check_birthdays(self) -> None:
         try:
@@ -58,15 +38,7 @@ class Tasks(Cog):
             due = await repository.users_due_birthday(now)
             await self._process_birthday_records(due)
         except Exception as e:  # noqa: BLE001
-            error_details: ErrorDetails = {
-                "type": type(e).__name__,
-                "message": str(e),
-                "args": e.args,
-                "traceback": traceback.format_exc(),
-            }
-            error_msg = f"Fatal error during birthday check task - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-            logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-            await self.log_error(error_msg, error_details["traceback"])
+            await report(e, "Fatal error during birthday check task")
 
     async def _process_birthday_records(self, due: list[DiscordUser]) -> None:
         now = pendulum.now("UTC")
@@ -74,7 +46,7 @@ class Tasks(Cog):
             try:
                 await self._process_birthday(record, now)
             except Exception as e:  # noqa: BLE001
-                await self._handle_fatal_error(
+                await report(
                     e,
                     f"Failed to process birthday for user {record.username} (ID: {record.id})",
                 )
@@ -112,10 +84,7 @@ class Tasks(Cog):
         user = self.bot.get_user(record.id)
         if user is None:
             logger.warning(f"Discord user ID {record.id} not found in guild cache")
-            await send_message(
-                f"_announce_birthday: User with ID {record.id} not found.",
-                config.channel("bot_admin"),
-            )
+            await notify(f"_announce_birthday: User with ID {record.id} not found.")
             return
         await send_message(
             config.template("discord_birthday", mention=user.mention),

--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import TypedDict
 
 TWITCH_MESSAGE_ID = "Twitch-Eventsub-Message-Id"
 TWITCH_MESSAGE_TYPE = "Twitch-Eventsub-Message-Type"
@@ -49,10 +48,3 @@ class TokenType(str, Enum):
     App = "app"
     User = "user"
     Broadcaster = "broadcaster"
-
-
-class ErrorDetails(TypedDict):
-    type: str
-    message: str
-    args: tuple
-    traceback: str

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -1,7 +1,5 @@
 import asyncio
-import io
 import logging
-import traceback
 from typing import Any
 
 import discord
@@ -18,10 +16,10 @@ from constants import (
     TWITCH_MESSAGE_SIGNATURE,
     TWITCH_MESSAGE_TIMESTAMP,
     TWITCH_MESSAGE_TYPE,
-    ErrorDetails,
     TokenType,
 )
 from db import LiveAlert, repository
+from errors import notify, report
 from models import (
     Channel,
     ChannelAdBreakBeginEventSub,
@@ -48,7 +46,6 @@ from services import (
     get_user,
     parse_rfc3339,
     send_embed,
-    send_message,
     start_alert_updater,
     twitch_send_message,
     verify_message,
@@ -82,9 +79,8 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
     if headers.get(TWITCH_MESSAGE_TYPE, "").lower() == "revocation":
         subscription: dict[str, Any] = body.get("subscription", {})
         condition = subscription.get("condition", {})
-        await send_message(
-            f"Revoked {subscription.get('type', 'unknown')} notifications for condition: {condition} because {subscription.get('status', 'No reason provided')}",
-            config.channel("bot_admin"),
+        await notify(
+            f"Revoked {subscription.get('type', 'unknown')} notifications for condition: {condition} because {subscription.get('status', 'No reason provided')}"
         )
         return Response(status_code=204)
 
@@ -97,33 +93,8 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
     twitch_message_signature = headers.get(TWITCH_MESSAGE_SIGNATURE, "")
     if not verify_message(secret_hmac, twitch_message_signature):
         logger.warning("403: Forbidden. Signature does not match.")
-        await send_message(
-            f"403: Forbidden request on {endpoint}. Signature does not match.",
-            config.channel("bot_admin"),
-        )
+        await notify(f"403: Forbidden request on {endpoint}. Signature does not match.")
         raise HTTPException(status_code=403)
-
-
-async def log_error(message: str, traceback_str: str) -> None:
-    traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-    traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-    await send_message(message, config.channel("bot_admin"), file=traceback_file)
-
-
-def get_error_details(e: Exception) -> ErrorDetails:
-    return {
-        "type": type(e).__name__,
-        "message": str(e),
-        "args": e.args,
-        "traceback": traceback.format_exc(),
-    }
-
-
-async def handle_error(e: Exception, context: str) -> None:
-    error_details = get_error_details(e)
-    error_msg = f"{context} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-    logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-    await log_error(error_msg, error_details["traceback"])
 
 
 async def process_webhook(
@@ -140,10 +111,7 @@ async def process_webhook(
             logger.warning(
                 f"400: Bad request. Invalid subscription type: {event_sub.subscription.type}"
             )
-            await send_message(
-                f"400: Bad request on {endpoint}. Invalid subscription type.",
-                config.channel("bot_admin"),
-            )
+            await notify(f"400: Bad request on {endpoint}. Invalid subscription type.")
             raise HTTPException(status_code=400)
 
         fire_and_forget(task_func(event_sub), name=endpoint)
@@ -151,7 +119,7 @@ async def process_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        await handle_error(e, f"500: Internal server error on {endpoint}")
+        await report(e, f"500: Internal server error on {endpoint}")
         raise HTTPException(status_code=500) from e
 
 
@@ -281,7 +249,7 @@ async def _save_live_alert(
             stream_info.started_at,
         )
     except Exception as e:  # noqa: BLE001
-        await handle_error(
+        await report(
             e,
             f"Failed to store live alert for broadcaster {broadcaster_id}",
         )
@@ -313,9 +281,8 @@ async def _stream_online_task(event_sub: StreamOnlineEventSub) -> None:
 
         message_id = await send_embed(embed, channel, view, content=content)
         if message_id is None:
-            await send_message(
-                f"Failed to send live alert message\nbroadcaster_id: {broadcaster_id}\nchannel_id: {channel}",
-                config.channel("bot_admin"),
+            await notify(
+                f"Failed to send live alert message\nbroadcaster_id: {broadcaster_id}\nchannel_id: {channel}"
             )
             logger.error(f"Failed to send embed for broadcaster {broadcaster_id}")
             return
@@ -323,7 +290,7 @@ async def _stream_online_task(event_sub: StreamOnlineEventSub) -> None:
         await _save_live_alert(broadcaster_id, channel, message_id, stream_info)
 
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, f"Error in _stream_online_task for {broadcaster_id}")
+        await report(e, f"Error in _stream_online_task for {broadcaster_id}")
 
 
 def _cancel_ad_break_task_if_needed(broadcaster_user_id: str) -> None:
@@ -362,9 +329,7 @@ async def _get_vod_info(broadcaster_id: int, stream_id: int) -> Video | None:
     try:
         return await get_stream_vod(broadcaster_id, stream_id)
     except Exception as e:  # noqa: BLE001
-        await handle_error(
-            e, f"Failed to fetch VOD info for broadcaster {broadcaster_id}"
-        )
+        await report(e, f"Failed to fetch VOD info for broadcaster {broadcaster_id}")
         return None
 
 
@@ -424,7 +389,7 @@ async def _update_offline_message(
         )
         return True
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error editing offline embed")
+        await report(e, "Error editing offline embed")
         return False
 
 
@@ -433,9 +398,7 @@ async def _cleanup_live_alert(broadcaster_id: int, message_id: int) -> None:
     try:
         await repository.delete_live_alert(broadcaster_id, message_id=message_id)
     except Exception as e:  # noqa: BLE001
-        await handle_error(
-            e, f"Failed to delete live alert for broadcaster {broadcaster_id}"
-        )
+        await report(e, f"Failed to delete live alert for broadcaster {broadcaster_id}")
 
 
 async def _stream_offline_task(event_sub: StreamOfflineEventSub) -> None:
@@ -463,7 +426,7 @@ async def _stream_offline_task(event_sub: StreamOfflineEventSub) -> None:
             await _cleanup_live_alert(broadcaster_id, message_id)
 
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, f"Error in _stream_offline_task for {broadcaster_id}")
+        await report(e, f"Error in _stream_offline_task for {broadcaster_id}")
 
 
 async def _channel_chat_message_task(event_sub: ChannelChatMessageEventSub) -> None:
@@ -484,7 +447,7 @@ async def _channel_chat_message_task(event_sub: ChannelChatMessageEventSub) -> N
 
         await dispatch(event_sub, command, args)
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error processing Twitch chat webhook task")
+        await report(e, "Error processing Twitch chat webhook task")
 
 
 async def _channel_follow_task(event_sub: ChannelFollowEventSub) -> None:
@@ -494,7 +457,7 @@ async def _channel_follow_task(event_sub: ChannelFollowEventSub) -> None:
             config.template("twitch_follow_thanks", user=event_sub.event.user_name),
         )
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error processing Twitch follow webhook task")
+        await report(e, "Error processing Twitch follow webhook task")
 
 
 _ad_break_notification_tasks: dict[str, asyncio.Task] = {}
@@ -538,7 +501,7 @@ async def _schedule_next_ad_break_notification(broadcaster_id: str) -> None:
         )
         raise
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error scheduling next ad break notification")
+        await report(e, "Error scheduling next ad break notification")
 
 
 async def _channel_ad_break_begin_task(event_sub: ChannelAdBreakBeginEventSub) -> None:
@@ -560,7 +523,7 @@ async def _channel_ad_break_begin_task(event_sub: ChannelAdBreakBeginEventSub) -
         task = asyncio.create_task(_schedule_next_ad_break_notification(broadcaster_id))
         _register_ad_break_task(broadcaster_id, task)
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error processing Twitch ad break webhook task")
+        await report(e, "Error processing Twitch ad break webhook task")
 
 
 async def _validate_oauth_identity(
@@ -577,10 +540,9 @@ async def _validate_oauth_identity(
         logger.error(
             "OAuth token validation failed with status=%s", response.status_code
         )
-        await send_message(
+        await notify(
             f"Failed to validate the Twitch token from {endpoint}: "
-            f"{response.status_code} {response.text}",
-            config.channel("bot_admin"),
+            f"{response.status_code} {response.text}"
         )
         raise HTTPException(status_code=500, detail="Twitch token validation failed")
 
@@ -602,7 +564,7 @@ async def _validate_oauth_identity(
     if problems:
         message = f"Rejected {token_type.value} authorization: {'; '.join(problems)}"
         logger.warning(message)
-        await send_message(message, config.channel("bot_admin"))
+        await notify(message)
         raise HTTPException(status_code=400, detail=message)
     return validation
 
@@ -617,10 +579,7 @@ async def _oauth_callback_common(
 ) -> tuple[RefreshResponse, TokenValidationResponse]:
     if not consume_authorization(token_type, state):
         logger.warning("400: Bad request on %s. Invalid OAuth state.", endpoint)
-        await send_message(
-            f"400: Bad request on {endpoint}. Invalid or expired OAuth state.",
-            config.channel("bot_admin"),
-        )
+        await notify(f"400: Bad request on {endpoint}. Invalid or expired OAuth state.")
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
 
     if error:
@@ -647,9 +606,8 @@ async def _oauth_callback_common(
         logger.error(
             f"Token exchange failed with status={response.status_code}, response={response.text}"
         )
-        await send_message(
-            f"Failed to exchange token: {response.status_code} {response.text}",
-            config.channel("bot_admin"),
+        await notify(
+            f"Failed to exchange token: {response.status_code} {response.text}"
         )
         raise HTTPException(status_code=500)
 
@@ -658,9 +616,8 @@ async def _oauth_callback_common(
         logger.error(
             f"Token exchange failed: unexpected token type {auth_response.token_type}"
         )
-        await send_message(
-            f"Failed to exchange token: unexpected token type {auth_response.token_type}",
-            config.channel("bot_admin"),
+        await notify(
+            f"Failed to exchange token: unexpected token type {auth_response.token_type}"
         )
         raise HTTPException(status_code=500)
     validation = await _validate_oauth_identity(auth_response, token_type, endpoint)
@@ -701,7 +658,7 @@ async def twitch_oauth_callback(
     except HTTPException:
         raise
     except Exception as e:
-        await handle_error(e, "500: Internal server error on /twitch/oauth/callback")
+        await report(e, "500: Internal server error on /twitch/oauth/callback")
         raise HTTPException(status_code=500) from e
 
 
@@ -730,7 +687,7 @@ async def twitch_oauth_callback_broadcaster(
     except HTTPException:
         raise
     except Exception as e:
-        await handle_error(
+        await report(
             e, "500: Internal server error on /twitch/oauth/callback/broadcaster"
         )
         raise HTTPException(status_code=500) from e
@@ -809,7 +766,7 @@ async def _channel_raid_task(event_sub: ChannelRaidEventSub) -> None:
                 f"!so {event_sub.event.from_broadcaster_user_login}",
             )
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error processing Twitch raid webhook task")
+        await report(e, "Error processing Twitch raid webhook task")
 
 
 @twitch_router.post("/webhook/twitch/raid")
@@ -834,7 +791,7 @@ async def _channel_moderate_task(event_sub: ChannelModerateEventSub) -> None:
             config.template("twitch_raid_farewell"),
         )
     except Exception as e:  # noqa: BLE001
-        await handle_error(e, "Error processing Twitch moderate webhook task")
+        await report(e, "Error processing Twitch moderate webhook task")
 
 
 @twitch_router.post("/webhook/twitch/moderate")

--- a/errors.py
+++ b/errors.py
@@ -1,7 +1,8 @@
 """Everything the bot says about itself, in one place.
 
-Neither function raises. A handler that can fail replaces the exception it was
-called to describe, and a lost report is worse than an ugly one.
+Neither function raises. Both run inside somebody's ``except`` block, where an
+escaping exception would replace the one being reported, and a lost report is
+worse than an ugly one.
 """
 
 import io
@@ -21,21 +22,29 @@ _MAX_CONTENT = 1900
 
 async def report(exc: Exception, context: str) -> None:
     """Log an exception, then deliver it and its traceback to the admin channel."""
-    summary = (
-        f"{context} - Type: {type(exc).__name__}, Message: {exc}, Args: {exc.args}"
-    )
-    # format_exception, not format_exc: an exception collected from
-    # asyncio.gather(return_exceptions=True) is not the one being handled, and
-    # format_exc would describe nothing.
-    trace = "".join(traceback.format_exception(exc))
-    logger.error("%s\nTraceback:\n%s", summary, trace)
-    await _deliver(summary, trace)
+    try:
+        summary = (
+            f"{context} - Type: {type(exc).__name__}, Message: {exc}, Args: {exc.args}"
+        )
+        # format_exception, not format_exc: an exception collected from
+        # asyncio.gather(return_exceptions=True) is not the one being handled,
+        # and format_exc would describe nothing.
+        trace = "".join(traceback.format_exception(exc))
+        logger.error("%s\nTraceback:\n%s", summary, trace)
+        await _deliver(summary, trace)
+    except Exception:
+        # Describing an exception can itself fail: a __str__ that raises, or a
+        # services import that never completed.
+        logger.exception("Reporting failed for: %s", context)
 
 
 async def notify(text: str) -> None:
     """Deliver a notice: something the admin channel should see that is not an exception."""
-    logger.warning(text)
-    await _deliver(text, None)
+    try:
+        logger.warning(text)
+        await _deliver(text, None)
+    except Exception:
+        logger.exception("Notifying failed for: %s", text)
 
 
 async def _deliver(text: str, trace: str | None) -> None:
@@ -47,18 +56,15 @@ async def _deliver(text: str, trace: str | None) -> None:
         logger.warning("Undelivered, no configuration loaded: %s", text)
         return
 
-    try:
-        from services.helper.helper import send_message
+    from services.helper.helper import send_message
 
-        file = (
-            discord.File(io.BytesIO(trace.encode("utf-8")), filename="traceback.txt")
-            if trace is not None
-            else None
-        )
-        sent = await send_message(
-            text[:_MAX_CONTENT], config.channel(_ADMIN_CHANNEL), file=file
-        )
-        if sent is None:
-            logger.warning("Undelivered, admin channel unavailable: %s", text)
-    except Exception:
-        logger.exception("Undelivered, admin channel raised: %s", text)
+    file = (
+        discord.File(io.BytesIO(trace.encode("utf-8")), filename="traceback.txt")
+        if trace is not None
+        else None
+    )
+    sent = await send_message(
+        text[:_MAX_CONTENT], config.channel(_ADMIN_CHANNEL), file=file
+    )
+    if sent is None:
+        logger.warning("Undelivered, admin channel unavailable: %s", text)

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,64 @@
+"""Everything the bot says about itself, in one place.
+
+Neither function raises. A handler that can fail replaces the exception it was
+called to describe, and a lost report is worse than an ugly one.
+"""
+
+import io
+import logging
+import traceback
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+_ADMIN_CHANNEL = "bot_admin"
+
+# Discord rejects a message over 2000 characters, and a rejected report is a
+# lost one. The traceback goes as a file, so only the summary is at risk.
+_MAX_CONTENT = 1900
+
+
+async def report(exc: Exception, context: str) -> None:
+    """Log an exception, then deliver it and its traceback to the admin channel."""
+    summary = (
+        f"{context} - Type: {type(exc).__name__}, Message: {exc}, Args: {exc.args}"
+    )
+    # format_exception, not format_exc: an exception collected from
+    # asyncio.gather(return_exceptions=True) is not the one being handled, and
+    # format_exc would describe nothing.
+    trace = "".join(traceback.format_exception(exc))
+    logger.error("%s\nTraceback:\n%s", summary, trace)
+    await _deliver(summary, trace)
+
+
+async def notify(text: str) -> None:
+    """Deliver a notice: something the admin channel should see that is not an exception."""
+    logger.warning(text)
+    await _deliver(text, None)
+
+
+async def _deliver(text: str, trace: str | None) -> None:
+    # Deferred: importing services at module scope runs the whole package, and
+    # main.py reports cog-load failures before any of it is up.
+    from services.config import config
+
+    if not config.loaded:
+        logger.warning("Undelivered, no configuration loaded: %s", text)
+        return
+
+    try:
+        from services.helper.helper import send_message
+
+        file = (
+            discord.File(io.BytesIO(trace.encode("utf-8")), filename="traceback.txt")
+            if trace is not None
+            else None
+        )
+        sent = await send_message(
+            text[:_MAX_CONTENT], config.channel(_ADMIN_CHANNEL), file=file
+        )
+        if sent is None:
+            logger.warning("Undelivered, admin channel unavailable: %s", text)
+    except Exception:
+        logger.exception("Undelivered, admin channel raised: %s", text)

--- a/errors.py
+++ b/errors.py
@@ -38,23 +38,30 @@ async def report(exc: Exception, context: str) -> None:
         logger.exception("Reporting failed for: %s", context)
 
 
-async def notify(text: str) -> None:
-    """Deliver a notice: something the admin channel should see that is not an exception."""
+async def notify(text: str) -> bool:
+    """Deliver a notice: something the admin channel should see that is not an exception.
+
+    Returns whether it landed, for the caller that retries. ``report`` returns
+    nothing because nothing retries an exception.
+    """
     try:
-        logger.warning(text)
-        await _deliver(text, None)
+        # Callers that have a severity log it themselves; this is the record
+        # that a notice was raised at all.
+        logger.info(text)
+        return await _deliver(text, None)
     except Exception:
         logger.exception("Notifying failed for: %s", text)
+        return False
 
 
-async def _deliver(text: str, trace: str | None) -> None:
+async def _deliver(text: str, trace: str | None) -> bool:
     # Deferred: importing services at module scope runs the whole package, and
     # main.py reports cog-load failures before any of it is up.
     from services.config import config
 
     if not config.loaded:
         logger.warning("Undelivered, no configuration loaded: %s", text)
-        return
+        return False
 
     from services.helper.helper import send_message
 
@@ -68,3 +75,5 @@ async def _deliver(text: str, trace: str | None) -> None:
     )
     if sent is None:
         logger.warning("Undelivered, admin channel unavailable: %s", text)
+        return False
+    return True

--- a/init/bot_init.py
+++ b/init/bot_init.py
@@ -2,11 +2,10 @@ import asyncio
 import logging
 
 import discord
-from discord import CategoryChannel, ForumChannel
-from discord.abc import PrivateChannel
 from discord.ext.commands import Bot
 
 from background import fire_and_forget
+from errors import notify
 
 logger = logging.getLogger(__name__)
 
@@ -91,10 +90,6 @@ async def on_ready() -> None:
         logger.info("Reconnected to Discord")
         return
 
-    channel = bot.get_channel(config.channel("bot_admin"))
-    if channel is None or isinstance(
-        channel, (ForumChannel, CategoryChannel, PrivateChannel)
-    ):
-        return
-    await channel.send(config.template("discord_startup"))
-    _startup_announced = True
+    # Only a delivered announcement counts as announced: one that could not be
+    # sent is tried again on the next reconnect.
+    _startup_announced = await notify(config.template("discord_startup"))

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ truststore.inject_into_ssl()
 import asyncio
 import logging
 import os
-import traceback
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Response
@@ -15,8 +14,9 @@ from rich.logging import RichHandler
 
 from background import fire_and_forget
 from config import settings
-from constants import COGS, ErrorDetails
+from constants import COGS
 from controller import twitch_router
+from errors import report
 from init import bot
 from services.helper.http_client import http_client_manager
 
@@ -27,19 +27,6 @@ logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
-def get_error_details(e: Exception) -> ErrorDetails:
-    return {
-        "type": type(e).__name__,
-        "message": str(e),
-        "args": e.args,
-        "traceback": traceback.format_exc(),
-    }
-
-
-def log_error(message: str, error_details: ErrorDetails):
-    logger.error(f"{message}\nTraceback:\n{error_details['traceback']}")
-
-
 async def main() -> None:
     try:
         bot.remove_command("help")
@@ -48,18 +35,10 @@ async def main() -> None:
         )
         for ext, res in zip(COGS, results):
             if isinstance(res, Exception):
-                error_details = get_error_details(res)
-                log_error(
-                    f"Failed to load extension {ext} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}",
-                    error_details,
-                )
+                await report(res, f"Failed to load extension {ext}")
         await bot.start(settings.active_discord_token)
     except Exception as e:  # noqa: BLE001
-        error_details = get_error_details(e)
-        log_error(
-            f"Unhandled exception in main - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}",
-            error_details,
-        )
+        await report(e, "Unhandled exception in main")
 
 
 @asynccontextmanager

--- a/services/helper/http_client.py
+++ b/services/helper/http_client.py
@@ -1,14 +1,10 @@
 import asyncio
-import io
 import logging
-import traceback
 from typing import Self, cast
 
-import discord
 import httpx
 
-from constants import ErrorDetails
-from services.config import config
+from errors import report
 
 logger = logging.getLogger(__name__)
 
@@ -100,25 +96,7 @@ class HttpClientManager:
 
             # Retryable errors will be logged by retry_api_call if all retries fail
             if not is_retryable:
-                from services.helper.helper import send_message
-
-                error_details: ErrorDetails = {
-                    "type": type(e).__name__,
-                    "message": str(e),
-                    "args": e.args,
-                    "traceback": traceback.format_exc(),
-                }
-                error_msg = f"HTTP request failed: {method} {url} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-                logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-                traceback_buffer = io.BytesIO(
-                    error_details["traceback"].encode("utf-8")
-                )
-                traceback_file = discord.File(
-                    traceback_buffer, filename="traceback.txt"
-                )
-                await send_message(
-                    error_msg, config.channel("bot_admin"), file=traceback_file
-                )
+                await report(e, f"HTTP request failed: {method} {url}")
 
             raise
 

--- a/services/helper/twitch.py
+++ b/services/helper/twitch.py
@@ -1,26 +1,17 @@
-import io
 import logging
-import traceback
 from typing import Literal
 
-import discord
 from httpx import Response
 
 from config import settings
-from constants import ErrorDetails, TokenType
+from constants import TokenType
+from errors import notify, report
 from models import ChannelChatMessageEventSub
 from services.config import config
-from services.helper.helper import send_message
 from services.helper.http_client import http_client_manager, is_transient_network_error
 from services.twitch.token_manager import token_manager
 
 logger = logging.getLogger(__name__)
-
-
-async def log_error(message: str, traceback_str: str) -> None:
-    traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-    traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-    await send_message(message, config.channel("bot_admin"), file=traceback_file)
 
 
 async def _ensure_token_available(token_type: TokenType) -> bool:
@@ -69,9 +60,7 @@ async def _make_http_request(
         return await http_client_manager.request("DELETE", url, headers=headers)
     else:
         logger.error(f"Unsupported HTTP method: {method}")
-        await send_message(
-            f"Unsupported HTTP method: {method}", config.channel("bot_admin")
-        )
+        await notify(f"Unsupported HTTP method: {method}")
         return None
 
 
@@ -100,10 +89,7 @@ async def call_twitch(
         refresh_success = await _ensure_token_available(token_type)
         if not refresh_success:
             logger.warning("No access token available and failed to refresh")
-            await send_message(
-                "No access token available and failed to refresh",
-                config.channel("bot_admin"),
-            )
+            await notify("No access token available and failed to refresh")
             return None
 
         token = _get_token_for_type(token_type)
@@ -130,15 +116,7 @@ async def call_twitch(
             # Re-raise retryable errors so retry_api_call can handle them
             raise
 
-        error_details: ErrorDetails = {
-            "type": type(e).__name__,
-            "message": str(e),
-            "args": e.args,
-            "traceback": traceback.format_exc(),
-        }
-        error_msg = f"Exception during Twitch API call - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-        logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-        await log_error(error_msg, error_details["traceback"])
+        await report(e, "Exception during Twitch API call")
         return None
 
 
@@ -172,18 +150,9 @@ async def twitch_send_message(broadcaster_id: str, message: str) -> None:
             logger.warning(
                 f"Failed to send message: {response.status_code if response else 'No response'}"
             )
-            await send_message(
-                f"Failed to send message: {response.status_code if response else 'No response'} {response.text if response else ''}",
-                config.channel("bot_admin"),
+            await notify(
+                f"Failed to send message: {response.status_code if response else 'No response'} {response.text if response else ''}"
             )
             return
     except Exception as e:  # noqa: BLE001
-        error_details: ErrorDetails = {
-            "type": type(e).__name__,
-            "message": str(e),
-            "args": e.args,
-            "traceback": traceback.format_exc(),
-        }
-        error_msg = f"Error sending Twitch message - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-        logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-        await log_error(error_msg, error_details["traceback"])
+        await report(e, "Error sending Twitch message")

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -1,8 +1,6 @@
 import asyncio
-import io
 import itertools
 import logging
-import traceback
 from collections.abc import Awaitable, Callable
 from enum import Enum, auto
 from typing import Any, Literal
@@ -12,8 +10,9 @@ import pendulum
 from discord.ui import View
 
 from config import settings
-from constants import ErrorDetails, TokenType
+from constants import TokenType
 from db import LiveAlert, repository
+from errors import notify, report
 from models import (
     AdSchedule,
     AdScheduleResponse,
@@ -33,7 +32,6 @@ from services.helper.helper import (
     edit_embed,
     get_age,
     parse_rfc3339,
-    send_message,
 )
 from services.helper.http_client import is_transient_network_error
 from services.helper.twitch import call_twitch
@@ -46,41 +44,12 @@ _UPDATE_INTERVAL_SECONDS = 60
 _MAX_INCONCLUSIVE_CYCLES = 5
 
 
-async def log_error(message: str, traceback_str: str) -> None:
-    traceback_buffer = io.BytesIO(traceback_str.encode("utf-8"))
-    traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-    await send_message(message, config.channel("bot_admin"), file=traceback_file)
-
-
-def _create_error_details(e: Exception) -> ErrorDetails:
-    """Create a standardized error details dictionary from an exception."""
-    return {
-        "type": type(e).__name__,
-        "message": str(e),
-        "args": e.args,
-        "traceback": traceback.format_exc(),
-    }
-
-
-async def _log_and_report_error(error_msg: str, error_details: ErrorDetails) -> None:
-    """Log an error and report it to the admin channel."""
-    logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-    await log_error(error_msg, error_details["traceback"])
-
-
-async def _handle_api_exception(e: Exception, context: str) -> None:
-    """Handle exceptions from API calls with standardized logging and reporting."""
-    error_details = _create_error_details(e)
-    error_msg = f"{context} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-    await _log_and_report_error(error_msg, error_details)
-
-
 async def _handle_invalid_response(response, context: str) -> None:
     """Handle invalid HTTP responses with standardized logging and reporting."""
     status = response.status_code if response else "No response"
     text = response.text if response else ""
     logger.warning(f"{context}: {status}")
-    await send_message(f"{context}: {status} {text}", config.channel("bot_admin"))
+    await notify(f"{context}: {status} {text}")
 
 
 async def retry_api_call[T](
@@ -125,7 +94,7 @@ async def retry_api_call[T](
 
 async def _handle_subscription_request_error(e: Exception) -> None:
     """Handle errors from subscription API requests."""
-    await _handle_api_exception(e, "Error fetching subscriptions after retries")
+    await report(e, "Error fetching subscriptions after retries")
 
 
 async def _handle_subscription_response_error(response) -> None:
@@ -187,7 +156,7 @@ async def get_user(id: int) -> User | None:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch user info after retries")
+        await report(e, "Failed to fetch user info after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -203,7 +172,7 @@ async def get_user_by_username(username: str) -> User | None:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch user info after retries")
+        await report(e, "Failed to fetch user info after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -231,9 +200,7 @@ async def twitch_event_subscription(
     try:
         response = await retry_api_call(call_twitch, "POST", url, body)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(
-            e, f"Failed to subscribe to {sub_type} event after retries"
-        )
+        await report(e, f"Failed to subscribe to {sub_type} event after retries")
         return False
 
     if response is None or not _is_valid_response(response):
@@ -248,7 +215,7 @@ async def subscribe_to_user(username: str) -> bool:
     user = await get_user_by_username(username)
     if not user:
         logger.warning(f"User not found: {username}")
-        await send_message(f"User not found: {username}", config.channel("bot_admin"))
+        await notify(f"User not found: {username}")
         return False
 
     return await twitch_event_subscription(
@@ -263,7 +230,7 @@ async def _delete_subscription(subscription_id: str) -> bool:
     try:
         response = await retry_api_call(call_twitch, "DELETE", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(
+        await report(
             e,
             f"Failed to unsubscribe subscription_id={subscription_id} after retries",
         )
@@ -283,7 +250,7 @@ async def unsubscribe_to_user(username: str) -> bool:
     user = await get_user_by_username(username)
     if not user:
         logger.warning(f"User not found: {username}")
-        await send_message(f"User not found: {username}", config.channel("bot_admin"))
+        await notify(f"User not found: {username}")
         return False
 
     subscriptions = await get_subscriptions()
@@ -318,7 +285,7 @@ async def _fetch_user_batch(batch: list[str]) -> list[User] | None:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Error fetching user infos after retries")
+        await report(e, "Error fetching user infos after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -351,7 +318,7 @@ async def get_channel(id: int) -> Channel | None:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch channel info after retries")
+        await report(e, "Failed to fetch channel info after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -368,7 +335,7 @@ async def get_stream_state(broadcaster_id: int) -> tuple[Stream | None, bool]:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch stream info after retries")
+        await report(e, "Failed to fetch stream info after retries")
         return None, False
 
     if response is None or not _is_valid_response(response):
@@ -379,7 +346,7 @@ async def get_stream_state(broadcaster_id: int) -> tuple[Stream | None, bool]:
         stream_info_response = StreamResponse.model_validate(response.json())
     except Exception as e:  # noqa: BLE001
         # A 200 whose body will not parse is still a lookup that told us nothing.
-        await _handle_api_exception(e, "Could not read the stream info response")
+        await report(e, "Could not read the stream info response")
         return None, False
 
     return (stream_info_response.data[0] if stream_info_response.data else None), True
@@ -396,7 +363,7 @@ async def get_stream_vod(user_id: int, stream_id: int) -> Video | None:
     try:
         response = await retry_api_call(call_twitch, "GET", url)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch VOD info after retries")
+        await report(e, "Failed to fetch VOD info after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -421,7 +388,7 @@ async def get_ad_schedule(broadcaster_id: int) -> AdSchedule | None:
             call_twitch, "GET", url, None, TokenType.Broadcaster
         )
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(e, "Failed to fetch ad schedule after retries")
+        await report(e, "Failed to fetch ad schedule after retries")
         return None
 
     if response is None or not _is_valid_response(response):
@@ -454,9 +421,7 @@ async def _fetch_vod_info_safely(broadcaster_id: int, stream_id: int) -> Video |
     try:
         return await get_stream_vod(broadcaster_id, stream_id)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(
-            e, f"Failed to fetch VOD info for broadcaster_id={broadcaster_id}"
-        )
+        await report(e, f"Failed to fetch VOD info for broadcaster_id={broadcaster_id}")
         return None
 
 
@@ -555,7 +520,7 @@ async def _clear_alert(broadcaster_id: int, message_id: int) -> None:
     try:
         await repository.delete_live_alert(broadcaster_id, message_id=message_id)
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(
+        await report(
             e,
             f"Failed to delete live alert record for broadcaster_id={broadcaster_id}",
         )
@@ -578,9 +543,7 @@ async def _handle_offline_edit_error(
         )
         return _CycleOutcome.RETRY
 
-    await _handle_api_exception(
-        e, f"Error editing offline embed for message_id={message_id}"
-    )
+    await report(e, f"Error editing offline embed for message_id={message_id}")
     return _CycleOutcome.STOP
 
 
@@ -694,12 +657,12 @@ async def _handle_live_embed_edit_error(
         )
         return _CycleOutcome.RETRY
 
-    error_details = _create_error_details(e)
-    if isinstance(e, discord.HTTPException):
-        error_msg = f"Discord HTTP error {e.status} when editing live embed for message_id={message_id} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-    else:
-        error_msg = f"Error editing live embed for message_id={message_id} - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-    await _log_and_report_error(error_msg, error_details)
+    context = (
+        f"Discord HTTP error {e.status} when editing live embed for message_id={message_id}"
+        if isinstance(e, discord.HTTPException)
+        else f"Error editing live embed for message_id={message_id}"
+    )
+    await report(e, context)
     return _CycleOutcome.RETRY
 
 
@@ -851,7 +814,7 @@ async def update_alert(
             except Exception as e:  # noqa: BLE001
                 # A cycle that raised concluded nothing, and must not take the
                 # updater with it; the cap below still stops a hopeless one.
-                await _handle_api_exception(
+                await report(
                     e,
                     f"Error in the live alert update cycle for broadcaster_id={broadcaster_id}",
                 )
@@ -868,7 +831,7 @@ async def update_alert(
                 return
 
     except Exception as e:  # noqa: BLE001
-        await _handle_api_exception(
+        await report(
             e, f"Error updating live alert message for broadcaster_id={broadcaster_id}"
         )
 

--- a/services/twitch/shoutout_queue.py
+++ b/services/twitch/shoutout_queue.py
@@ -1,17 +1,14 @@
 import asyncio
 import contextlib
-import io
 import logging
-import traceback
 from typing import ClassVar, Self, cast
 
-import discord
 import httpx
 import pendulum
 
-from constants import ErrorDetails, TokenType
+from constants import TokenType
+from errors import notify, report
 from services.config import config
-from services.helper.helper import send_message
 from services.helper.twitch import call_twitch
 from services.twitch.api import get_user
 
@@ -99,10 +96,7 @@ class TwitchShoutoutQueue:
                     logger.warning(
                         "User id %s (%s) not found for shoutout", user_id_str, login
                     )
-                    await send_message(
-                        f"User {login} not found for shoutout",
-                        config.channel("bot_admin"),
-                    )
+                    await notify(f"User {login} not found for shoutout")
                     continue
 
                 url = "https://api.twitch.tv/helix/chat/shoutouts"
@@ -138,24 +132,11 @@ class TwitchShoutoutQueue:
                     response.status_code if response else "No response",
                     response.text if response else "",
                 )
-                await send_message(
-                    f"Failed to send shoutout to {login}: {response.status_code if response else 'No response'} {response.text if response else ''}",
-                    config.channel("bot_admin"),
+                await notify(
+                    f"Failed to send shoutout to {login}: {response.status_code if response else 'No response'} {response.text if response else ''}"
                 )
         except Exception as e:  # noqa: BLE001
-            error_details: ErrorDetails = {
-                "type": type(e).__name__,
-                "message": str(e),
-                "args": e.args,
-                "traceback": traceback.format_exc(),
-            }
-            error_msg = f"Error in activate method - Type: {error_details['type']}, Message: {error_details['message']}, Args: {error_details['args']}"
-            logger.error(f"{error_msg}\nTraceback:\n{error_details['traceback']}")
-            traceback_buffer = io.BytesIO(error_details["traceback"].encode("utf-8"))
-            traceback_file = discord.File(traceback_buffer, filename="traceback.txt")
-            await send_message(
-                error_msg, config.channel("bot_admin"), file=traceback_file
-            )
+            await report(e, "Error in activate method")
 
     def deactivate(self) -> None:
         self._activated = False

--- a/services/twitch/token_manager.py
+++ b/services/twitch/token_manager.py
@@ -13,9 +13,9 @@ from config import settings
 from constants import TokenType
 from db import OAuthToken, OAuthTokenKey
 from db.session import session_scope
+from errors import notify
 from models import AuthResponse, RefreshResponse
 from services.config import config
-from services.helper.helper import send_message
 from services.helper.http_client import http_client_manager
 
 logger = logging.getLogger(__name__)
@@ -170,19 +170,15 @@ class TwitchTokenManager:
 
         if response.status_code < 200 or response.status_code >= 300:
             logger.error(f"Token refresh failed with status={response.status_code}")
-            await send_message(
-                f"Failed to refresh access token: {response.status_code} {response.text}",
-                config.channel("bot_admin"),
+            await notify(
+                f"Failed to refresh access token: {response.status_code} {response.text}"
             )
             return False
 
         auth_response = AuthResponse.model_validate(response.json())
         if auth_response.token_type != "bearer":
             logger.error(f"Unexpected token type received: {auth_response.token_type}")
-            await send_message(
-                f"Unexpected token type: {auth_response.token_type}",
-                config.channel("bot_admin"),
-            )
+            await notify(f"Unexpected token type: {auth_response.token_type}")
             return False
 
         await self._store(
@@ -226,9 +222,7 @@ class TwitchTokenManager:
         refresh_token = self._refresh.get(token_type)
         if not refresh_token:
             logger.error(f"No {label} refresh token available")
-            await send_message(
-                f"No {label} refresh token available", config.channel("bot_admin")
-            )
+            await notify(f"No {label} refresh token available")
             return False
 
         params = {
@@ -245,20 +239,16 @@ class TwitchTokenManager:
             logger.error(
                 f"{label} token refresh failed with status={response.status_code}"
             )
-            await send_message(
+            await notify(
                 f"Failed to refresh {label} access token: "
-                f"{response.status_code} {response.text}",
-                config.channel("bot_admin"),
+                f"{response.status_code} {response.text}"
             )
             return False
 
         auth_response = RefreshResponse.model_validate(response.json())
         if auth_response.token_type != "bearer":
             logger.error(f"Unexpected token type received: {auth_response.token_type}")
-            await send_message(
-                f"Unexpected token type: {auth_response.token_type}",
-                config.channel("bot_admin"),
-            )
+            await notify(f"Unexpected token type: {auth_response.token_type}")
             return False
 
         await self._store_refreshed(token_type, auth_response)


### PR DESCRIPTION
Fifteen named definitions across nine files spelled out one behaviour: build a details dict, format a summary, log it, upload the traceback to the admin channel. errors.py now owns it behind report(exc, context) and notify(text), and nothing else resolves config.channel("bot_admin").

Neither function raises. Nothing guarded the old sends, so a permissions error inside a handler replaced the exception being reported.

Two failures stop being silent. send_message returns None when the channel is not cached, which every old copy discarded; a report that cannot be delivered now says why. And the details dict used format_exc(), which describes nothing for an exception carried out of asyncio.gather(return_exceptions=True) - every cog-load failure logged "NoneType: None" as its traceback. Formatting the passed exception fixes it.

CONTEXT.md records the vocabulary this introduced: admin channel, report, notice.

## Summary by Sourcery

Centralize exception reporting and administrative notifications in a non-raising errors module so failures are logged, delivered consistently, and never handled silently.

New Features:
- Add centralized `report` and `notify` APIs for delivering exception reports and administrative notices.

Bug Fixes:
- Preserve the original exception traceback when reporting errors outside the active exception context.
- Prevent reporting failures from replacing or masking the original application exception.
- Surface undelivered administrative messages and retry startup announcements when delivery fails.

Enhancements:
- Consolidate error and admin-channel messaging across bot, webhook, task, Twitch API, and token-management code.
- Ensure reports are logged locally before delivery and enforce safe message length limits.
- Document the shared terminology for admin-channel reports, notices, and related bot concepts.

Documentation:
- Add CONTEXT.md defining project-wide terminology for administrative reporting and Twitch stream lifecycle concepts.
- Update contributor guidance to require centralized error and notice handling.

Chores:
- Remove duplicated error-detail types and reporting helpers from individual modules.