### PR TITLE
feat: Add Twitch OAuth reauthorization flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ guard an UPDATE with the value it replaces — read it before touching `migratio
 **Nothing connects at import time.** `db/session.py` builds the engine lazily, so
 importing any module is safe without a reachable `DATABASE_URL`.
 
+**Twitch user grants start in Discord.** The owner-only `/twitch-auth` command
+creates short-lived links for the `user` (the account in `twitch_bot_user_id`)
+and `broadcaster` (the account in `twitch_broadcaster_id`) authorization-code
+flows. Both request `twitch_app_scopes`; the callbacks validate the returned
+Twitch user ID, client ID and scopes before upserting `oauth_token`. The `app`
+row is separate, uses client credentials and has no refresh token.
+
 **Two model packages with confusable names.** `models/` is Pydantic: Twitch API
 responses and EventSub payloads. `db/models/` is SQLModel: the tables.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,45 @@ the bot will mint an app token on demand.
 To exercise webhooks you need the tunnel, which is what `start.sh` sets up in
 the container.
 
+## Reauthorizing Twitch accounts
+
+The `oauth_token` table has three identities. The `app` row is minted through
+Twitch's client-credentials flow and correctly has no refresh token. The `user`
+and `broadcaster` rows come from Twitch's authorization-code flow and each need
+an access token and refresh token.
+
+Before reauthorizing, register both exact production callback URLs in the
+[Twitch developer console](https://dev.twitch.tv/console/apps):
+
+```text
+<APP_URL>/twitch/oauth/callback
+<APP_URL>/twitch/oauth/callback/broadcaster
+```
+
+Run `/twitch-auth` in Discord as the configured `owner_id`. It returns two
+ephemeral, ten-minute links:
+
+1. **User:** authorize the bot/moderator Twitch account whose ID is stored in
+   `twitch_bot_user_id`. The bot sends that ID as `moderator_id`, so Twitch
+   requires it to match this access token.
+2. **Broadcaster:** authorize the channel-owner Twitch account whose ID is
+   stored in `twitch_broadcaster_id`. Twitch requires the ad-schedule token's
+   user ID to match this broadcaster ID.
+
+Use a private browser window or sign out between grants if the accounts differ.
+Both links request the scopes in the `twitch_app_scopes` app setting and force
+Twitch to show the authorization step. Before storing anything, the callback
+uses Twitch's validation endpoint to reject the wrong account, client ID, or an
+incomplete scope grant. A successful callback upserts only its corresponding
+`user` or `broadcaster` row; it does not change the working `app` row.
+
+The implementation follows Twitch's current documentation for the
+[authorization-code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#authorization-code-grant-flow),
+[token validation](https://dev.twitch.tv/docs/authentication/validate-tokens/),
+[refresh-token rotation](https://dev.twitch.tv/docs/authentication/refresh-tokens/),
+[shoutout authorization](https://dev.twitch.tv/docs/api/reference/#send-a-shoutout),
+and [ad-schedule authorization](https://dev.twitch.tv/docs/api/reference/#get-ad-schedule).
+
 ### Pointing the test bot at a test guild
 
 `guild_id` is an `app_setting` row, not a constant. To keep local runs out of

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -11,6 +11,7 @@ from discord import (
 )
 from discord.ext.commands import Bot, Cog
 
+from constants import TokenType
 from services import (
     get_subscriptions,
     get_users,
@@ -19,6 +20,7 @@ from services import (
     unsubscribe_to_user,
 )
 from services.config import config
+from services.twitch.oauth import create_authorization_start_url
 from views import role_panels
 
 logger = logging.getLogger(__name__)
@@ -107,6 +109,51 @@ class Admin(Cog):
         for embed, view, channel_id in role_panels("roles"):
             await send_embed(embed, channel_id, view)
         await interaction.response.send_message(config.template("admin_roles_sent"))
+
+    @app_commands.command(
+        name="twitch-auth",
+        description="Generate owner-only links for the two Twitch user grants",
+    )
+    @app_commands.commands.default_permissions(administrator=True)
+    async def twitch_auth(self, interaction: Interaction) -> None:
+        if interaction.user.id != config.setting("owner_id"):
+            await interaction.response.send_message(
+                "Only the configured bot owner can replace Twitch OAuth grants.",
+                ephemeral=True,
+            )
+            return
+
+        bot_user_id = config.setting("twitch_bot_user_id")
+        broadcaster_id = config.setting("twitch_broadcaster_id")
+        broadcaster_username = config.setting("broadcaster_username")
+
+        view = discord.ui.View(timeout=600)
+        view.add_item(
+            discord.ui.Button(
+                label="1. Authorize bot account",
+                style=discord.ButtonStyle.link,
+                url=create_authorization_start_url(TokenType.User),
+            )
+        )
+        view.add_item(
+            discord.ui.Button(
+                label="2. Authorize broadcaster",
+                style=discord.ButtonStyle.link,
+                url=create_authorization_start_url(TokenType.Broadcaster),
+            )
+        )
+        await interaction.response.send_message(
+            "Create the two missing `oauth_token` grants:\n"
+            f"1. **User:** log in as the bot/moderator account with Twitch ID "
+            f"`{bot_user_id}`.\n"
+            f"2. **Broadcaster:** log in as `{broadcaster_username}` with Twitch ID "
+            f"`{broadcaster_id}`.\n\n"
+            "Twitch will be forced to show the authorization step. Each link expires "
+            "after 10 minutes and can be completed once. The callback rejects a token "
+            "from the wrong account or with missing configured scopes.",
+            view=view,
+            ephemeral=True,
+        )
 
     @app_commands.command(description="Gets all active subscriptions' users")
     @app_commands.commands.default_permissions(administrator=True)

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -8,6 +8,7 @@ import discord
 import pendulum
 from discord.ui import View
 from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
 
 from background import fire_and_forget
 from config import settings
@@ -18,6 +19,7 @@ from constants import (
     TWITCH_MESSAGE_TIMESTAMP,
     TWITCH_MESSAGE_TYPE,
     ErrorDetails,
+    TokenType,
 )
 from db import LiveAlert, repository
 from models import (
@@ -30,6 +32,7 @@ from models import (
     RefreshResponse,
     StreamOfflineEventSub,
     StreamOnlineEventSub,
+    TokenValidationResponse,
     User,
     Video,
 )
@@ -53,6 +56,13 @@ from services import (
 from services.config import config
 from services.helper.http_client import http_client_manager
 from services.twitch.commands import dispatch
+from services.twitch.oauth import (
+    authorization_url,
+    callback_uri,
+    configured_scopes,
+    consume_authorization,
+    expected_user_id,
+)
 from services.twitch.shoutout_queue import shoutout_queue
 from services.twitch.token_manager import token_manager
 
@@ -553,26 +563,84 @@ async def _channel_ad_break_begin_task(event_sub: ChannelAdBreakBeginEventSub) -
         await handle_error(e, "Error processing Twitch ad break webhook task")
 
 
-async def _oauth_callback_common(
-    code: str, state: str, endpoint: str
-) -> RefreshResponse:
-    if state != settings.twitch_webhook_secret:
-        logger.warning(f"400: Bad request. Invalid state: {state}")
+async def _validate_oauth_identity(
+    auth_response: RefreshResponse,
+    token_type: TokenType,
+    endpoint: str,
+) -> TokenValidationResponse:
+    response = await http_client_manager.request(
+        "GET",
+        "https://id.twitch.tv/oauth2/validate",
+        headers={"Authorization": f"OAuth {auth_response.access_token}"},
+    )
+    if response.status_code < 200 or response.status_code >= 300:
+        logger.error(
+            "OAuth token validation failed with status=%s", response.status_code
+        )
         await send_message(
-            f"400: Bad request on {endpoint}. Invalid state.",
+            f"Failed to validate the Twitch token from {endpoint}: "
+            f"{response.status_code} {response.text}",
             config.channel("bot_admin"),
         )
-        raise HTTPException(status_code=400)
+        raise HTTPException(status_code=500, detail="Twitch token validation failed")
+
+    validation = TokenValidationResponse.model_validate(response.json())
+    expected_id = expected_user_id(token_type)
+    missing_scopes = sorted(set(configured_scopes()) - set(validation.scopes))
+
+    problems = []
+    if validation.client_id != settings.twitch_client_id:
+        problems.append("the token belongs to a different Twitch application")
+    if validation.user_id != expected_id:
+        problems.append(
+            f"expected Twitch user ID {expected_id}, but {validation.login} "
+            f"authorized as ID {validation.user_id}"
+        )
+    if missing_scopes:
+        problems.append(f"missing scopes: {', '.join(missing_scopes)}")
+
+    if problems:
+        message = f"Rejected {token_type.value} authorization: {'; '.join(problems)}"
+        logger.warning(message)
+        await send_message(message, config.channel("bot_admin"))
+        raise HTTPException(status_code=400, detail=message)
+    return validation
+
+
+async def _oauth_callback_common(
+    code: str | None,
+    state: str,
+    endpoint: str,
+    token_type: TokenType,
+    error: str | None,
+    error_description: str | None,
+) -> tuple[RefreshResponse, TokenValidationResponse]:
+    if not consume_authorization(token_type, state):
+        logger.warning("400: Bad request on %s. Invalid OAuth state.", endpoint)
+        await send_message(
+            f"400: Bad request on {endpoint}. Invalid or expired OAuth state.",
+            config.channel("bot_admin"),
+        )
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+
+    if error:
+        detail = error_description or error
+        logger.warning("Twitch authorization denied on %s: %s", endpoint, detail)
+        raise HTTPException(
+            status_code=400, detail=f"Twitch authorization denied: {detail}"
+        )
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing Twitch authorization code")
 
     params = {
         "client_id": settings.twitch_client_id,
         "client_secret": settings.twitch_client_secret,
         "code": code,
         "grant_type": "authorization_code",
-        "redirect_uri": f"{settings.app_url}{endpoint}",
+        "redirect_uri": callback_uri(token_type),
     }
     response = await http_client_manager.request(
-        "POST", "https://id.twitch.tv/oauth2/token", params=params
+        "POST", "https://id.twitch.tv/oauth2/token", data=params
     )
 
     if response.status_code < 200 or response.status_code >= 300:
@@ -595,18 +663,40 @@ async def _oauth_callback_common(
             config.channel("bot_admin"),
         )
         raise HTTPException(status_code=500)
-    return auth_response
+    validation = await _validate_oauth_identity(auth_response, token_type, endpoint)
+    return auth_response, validation
+
+
+@twitch_router.get("/twitch/oauth/start/{identity}")
+async def twitch_oauth_start(identity: str, state: str) -> Response:
+    try:
+        token_type = TokenType(identity)
+        return RedirectResponse(authorization_url(token_type, state), status_code=302)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None
 
 
 @twitch_router.get("/twitch/oauth/callback")
-async def twitch_oauth_callback(code: str, state: str) -> Response:
+async def twitch_oauth_callback(
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+) -> Response:
     try:
-        auth_response = await _oauth_callback_common(
-            code, state, "/twitch/oauth/callback"
+        auth_response, validation = await _oauth_callback_common(
+            code,
+            state,
+            "/twitch/oauth/callback",
+            TokenType.User,
+            error,
+            error_description,
         )
         await token_manager.set_user_access_token(auth_response)
         return Response(
-            "Authorization successful! You can close this tab.", status_code=200
+            f"Authorization successful for bot account {validation.login} "
+            f"({validation.user_id}). You can close this tab.",
+            status_code=200,
         )
     except HTTPException:
         raise
@@ -616,14 +706,26 @@ async def twitch_oauth_callback(code: str, state: str) -> Response:
 
 
 @twitch_router.get("/twitch/oauth/callback/broadcaster")
-async def twitch_oauth_callback_broadcaster(code: str, state: str) -> Response:
+async def twitch_oauth_callback_broadcaster(
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+) -> Response:
     try:
-        auth_response = await _oauth_callback_common(
-            code, state, "/twitch/oauth/callback/broadcaster"
+        auth_response, validation = await _oauth_callback_common(
+            code,
+            state,
+            "/twitch/oauth/callback/broadcaster",
+            TokenType.Broadcaster,
+            error,
+            error_description,
         )
         await token_manager.set_broadcaster_access_token(auth_response)
         return Response(
-            "Authorization successful! You can close this tab.", status_code=200
+            f"Authorization successful for broadcaster account {validation.login} "
+            f"({validation.user_id}). You can close this tab.",
+            status_code=200,
         )
     except HTTPException:
         raise

--- a/db/README.md
+++ b/db/README.md
@@ -90,9 +90,10 @@ Two caveats:
 * **Do not migrate the current values.** Twitch issues a new refresh token on
   every refresh and invalidates the previous one, so any copied token is dead as
   soon as the running bot refreshes. Create the rows empty and let them fill at
-  cutover: the app token needs one `client_credentials` call, and the user and
-  broadcaster tokens one trip each through the existing callbacks at
-  `/twitch/oauth/callback` and `/twitch/oauth/callback/broadcaster`.
+  cutover: the app token needs one `client_credentials` call and correctly has no
+  refresh token. Run the owner-only `/twitch-auth` Discord command to create the
+  user and broadcaster grants through `/twitch/oauth/callback` and
+  `/twitch/oauth/callback/broadcaster`.
 
 `expires_at` is what allows a token to be refreshed *before* it lapses instead
 of after a request comes back 401. `TwitchTokenManager` already tracks this in

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,4 @@
-from .auth.auth_response import AuthResponse, RefreshResponse
+from .auth.auth_response import AuthResponse, RefreshResponse, TokenValidationResponse
 from .twitch_api_responses.ad_schedule import AdSchedule, AdScheduleResponse
 from .twitch_api_responses.channel import Channel, ChannelResponse
 from .twitch_api_responses.stream import Stream, StreamResponse
@@ -34,6 +34,7 @@ __all__ = [
     "StreamResponse",
     "Subscription",
     "SubscriptionResponse",
+    "TokenValidationResponse",
     "User",
     "UserResponse",
     "Video",

--- a/models/auth/auth_response.py
+++ b/models/auth/auth_response.py
@@ -13,3 +13,11 @@ class RefreshResponse(BaseModel):
     refresh_token: str
     scope: list[str] | str
     token_type: str
+
+
+class TokenValidationResponse(BaseModel):
+    client_id: str
+    login: str
+    scopes: list[str]
+    user_id: str
+    expires_in: int

--- a/services/twitch/oauth.py
+++ b/services/twitch/oauth.py
@@ -1,0 +1,117 @@
+"""Owner-initiated Twitch authorization-code grants."""
+
+import secrets
+import time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+from config import settings
+from constants import TokenType
+from services.config import config
+
+_AUTHORIZATION_TTL_SECONDS = 10 * 60
+_AUTHORIZATION_ENDPOINT = "https://id.twitch.tv/oauth2/authorize"
+
+
+@dataclass(frozen=True)
+class PendingAuthorization:
+    token_type: TokenType
+    expires_at: float
+
+
+_pending_authorizations: dict[str, PendingAuthorization] = {}
+
+
+def _require_user_identity(token_type: TokenType) -> None:
+    if token_type not in {TokenType.User, TokenType.Broadcaster}:
+        raise ValueError(f"OAuth authorization is not available for {token_type.value}")
+
+
+def _prune_expired_authorizations() -> None:
+    now = time.monotonic()
+    expired = [
+        state
+        for state, authorization in _pending_authorizations.items()
+        if authorization.expires_at <= now
+    ]
+    for state in expired:
+        del _pending_authorizations[state]
+
+
+def configured_scopes() -> list[str]:
+    scopes = config.setting("twitch_app_scopes")
+    if not isinstance(scopes, list) or not scopes:
+        raise RuntimeError("twitch_app_scopes must be a non-empty JSON list")
+    if not all(isinstance(scope, str) and scope for scope in scopes):
+        raise RuntimeError("twitch_app_scopes contains an invalid scope")
+    return scopes
+
+
+def callback_uri(token_type: TokenType) -> str:
+    _require_user_identity(token_type)
+    path = (
+        "/twitch/oauth/callback/broadcaster"
+        if token_type is TokenType.Broadcaster
+        else "/twitch/oauth/callback"
+    )
+    return f"{settings.app_url.rstrip('/')}{path}"
+
+
+def expected_user_id(token_type: TokenType) -> str:
+    _require_user_identity(token_type)
+    setting = (
+        "twitch_broadcaster_id"
+        if token_type is TokenType.Broadcaster
+        else "twitch_bot_user_id"
+    )
+    user_id = config.setting(setting)
+    if not isinstance(user_id, str) or not user_id:
+        raise RuntimeError(f"{setting} must be a non-empty string")
+    return user_id
+
+
+def create_authorization_start_url(token_type: TokenType) -> str:
+    """Create a short-lived link suitable for an ephemeral Discord button."""
+    _require_user_identity(token_type)
+    _prune_expired_authorizations()
+    state = secrets.token_urlsafe(32)
+    _pending_authorizations[state] = PendingAuthorization(
+        token_type=token_type,
+        expires_at=time.monotonic() + _AUTHORIZATION_TTL_SECONDS,
+    )
+    query = urlencode({"state": state})
+    return (
+        f"{settings.app_url.rstrip('/')}/twitch/oauth/start/{token_type.value}?{query}"
+    )
+
+
+def authorization_url(token_type: TokenType, state: str) -> str:
+    """Build Twitch's consent URL if state is live and bound to this identity."""
+    _require_user_identity(token_type)
+    _prune_expired_authorizations()
+    pending = _pending_authorizations.get(state)
+    if pending is None or pending.token_type is not token_type:
+        raise ValueError("Invalid or expired OAuth state")
+
+    query = urlencode(
+        {
+            "response_type": "code",
+            "client_id": settings.twitch_client_id,
+            "redirect_uri": callback_uri(token_type),
+            "scope": " ".join(configured_scopes()),
+            "state": state,
+            "force_verify": "true",
+        }
+    )
+    return f"{_AUTHORIZATION_ENDPOINT}?{query}"
+
+
+def consume_authorization(token_type: TokenType, state: str) -> bool:
+    """Consume a state once, accepting it only for the identity it was issued for."""
+    _require_user_identity(token_type)
+    _prune_expired_authorizations()
+    pending = _pending_authorizations.get(state)
+    if pending is None or pending.token_type is not token_type:
+        return False
+    del _pending_authorizations[state]
+    return True

--- a/services/twitch/token_manager.py
+++ b/services/twitch/token_manager.py
@@ -238,7 +238,7 @@ class TwitchTokenManager:
             "refresh_token": refresh_token,
         }
         response = await http_client_manager.request(
-            "POST", "https://id.twitch.tv/oauth2/token", params=params
+            "POST", "https://id.twitch.tv/oauth2/token", data=params
         )
 
         if response.status_code < 200 or response.status_code >= 300:


### PR DESCRIPTION
## Summary by Sourcery

Enable secure owner-initiated reauthorization of the Twitch bot and broadcaster accounts.

New Features:
- Add an owner-only Discord command that generates short-lived authorization links for the configured Twitch bot and broadcaster accounts.
- Add separate Twitch OAuth authorization and callback flows for user and broadcaster grants, including forced consent and account-specific redirect handling.

Bug Fixes:
- Validate Twitch OAuth grants before storage to reject tokens from the wrong application or account and tokens missing configured scopes.
- Send token exchange and refresh parameters in the request body as required by Twitch.

Enhancements:
- Use one-time, expiring, identity-bound OAuth state values and retain the existing app client-credentials token separately from user grants.

Documentation:
- Document Twitch account reauthorization, callback URL registration, required identities, and grant validation behavior.