### PR TITLE
fix: Stop calling five healthy subscription types undeliverable

### DIFF
--- a/init/bot_init.py
+++ b/init/bot_init.py
@@ -45,7 +45,11 @@ async def check_subscriptions() -> None:
     the most expensive failure here and the quietest.
     """
     from errors import notify, report
-    from services.twitch.api import expected_callbacks, get_subscriptions
+    from services.twitch.api import (
+        get_subscriptions,
+        subscription_target,
+        undeliverable,
+    )
     from services.twitch.helix import HelixError
 
     try:
@@ -55,24 +59,17 @@ async def check_subscriptions() -> None:
         await report(e, "Could not check the Twitch subscriptions at startup")
         return
 
-    callbacks = expected_callbacks()
     broken = [
-        f"- {subscription.type} for broadcaster "
-        f"{subscription.condition.broadcaster_user_id}: {subscription.status}"
-        + (
-            ""
-            if subscription.transport.callback in callbacks
-            else f", calling back on {subscription.transport.callback}"
-        )
+        f"- {subscription.type} ({subscription_target(subscription)}): {reason}"
         for subscription in subscriptions
-        if subscription.status != "enabled"
-        or subscription.transport.callback not in callbacks
+        if (reason := undeliverable(subscription)) is not None
     ]
     if broken:
         detail = "\n".join(broken)
         await notify(
             f"{len(broken)} Twitch subscription(s) will not deliver:\n{detail}\n"
-            "Re-run /subscribe for each broadcaster to replace them."
+            "/subscribe replaces the stream.online and stream.offline pair; the"
+            " rest are registered outside the bot."
         )
 
 

--- a/models/twitch_api_responses/subscription.py
+++ b/models/twitch_api_responses/subscription.py
@@ -3,6 +3,12 @@ from pydantic import BaseModel
 
 class SubscriptionCondition(BaseModel):
     broadcaster_user_id: str | None = None
+    # A raid is keyed on the two ends rather than one broadcaster, and a
+    # moderate subscription carries the moderator as well.
+    to_broadcaster_user_id: str | None = None
+    from_broadcaster_user_id: str | None = None
+    moderator_user_id: str | None = None
+    user_id: str | None = None
 
 
 class SubscriptionTransport(BaseModel):

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -284,15 +284,19 @@ async def unsubscribe_to_user(username: str) -> bool:
 def subscription_target(subscription: Subscription) -> str:
     """Whichever id identifies this subscription, since the field varies by type."""
     condition = subscription.condition
-    for label, value in (
-        ("broadcaster", condition.broadcaster_user_id),
-        ("to broadcaster", condition.to_broadcaster_user_id),
-        ("from broadcaster", condition.from_broadcaster_user_id),
-        ("user", condition.user_id),
-    ):
-        if value:
-            return f"{label} {value}"
-    return f"id {subscription.id}"
+    return next(
+        (
+            f"{label} {value}"
+            for label, value in (
+                ("broadcaster", condition.broadcaster_user_id),
+                ("to broadcaster", condition.to_broadcaster_user_id),
+                ("from broadcaster", condition.from_broadcaster_user_id),
+                ("user", condition.user_id),
+            )
+            if value
+        ),
+        f"id {subscription.id}",
+    )
 
 
 def undeliverable(subscription: Subscription) -> str | None:
@@ -301,13 +305,19 @@ def undeliverable(subscription: Subscription) -> str | None:
     Two things are checkable without knowing which event types the bot expects,
     and only two: Twitch having disabled it, and a callback pointing elsewhere.
     Matching whole URLs instead would call every event type the bot does not
-    create itself — chat, follows, raids — undeliverable on every start. The
-    case this cannot see, a callback on the right host with a wrong path, fails
-    its deliveries until Twitch disables it, which the first check then catches.
+    create itself — chat, follows, raids — undeliverable on every start.
+
+    The prefix has to end at a path boundary. A bare ``startswith`` also accepts
+    ``/webhook/twitching`` and ``/webhook/twitch-old``, which are different paths
+    that FastAPI does not route. What is left uncovered is an unrouted segment
+    *under* the prefix, and that fails its deliveries until Twitch disables it,
+    which the status check above then catches.
     """
     if subscription.status != "enabled":
         return subscription.status
+
     callback = subscription.transport.callback or ""
-    if not callback.startswith(callback_prefix()):
+    prefix = callback_prefix()
+    if callback != prefix and not callback.startswith(f"{prefix}/"):
         return f"calling back on {callback or 'nothing'}"
     return None

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -154,12 +154,20 @@ async def send_shoutout(to_broadcaster_id: str) -> None:
     )
 
 
+def callback_prefix() -> str:
+    """What every EventSub callback for this deployment starts with.
+
+    All seven webhook routes live under it, so a callback that does not begin
+    here belongs to another deployment or to this one before it moved. rstrip
+    to match services/twitch/oauth.py: a trailing slash in APP_URL would
+    otherwise build a //webhook/twitch that Twitch dutifully calls and FastAPI
+    does not route.
+    """
+    return f"{settings.app_url.rstrip('/')}/webhook/twitch"
+
+
 def _callback_url(sub_type: Literal["online", "offline"]) -> str:
-    suffix = "" if sub_type == "online" else "/offline"
-    # rstrip to match services/twitch/oauth.py: a trailing slash in APP_URL
-    # would otherwise build a //webhook/twitch that Twitch dutifully calls and
-    # FastAPI does not route.
-    return f"{settings.app_url.rstrip('/')}/webhook/twitch{suffix}"
+    return f"{callback_prefix()}{'' if sub_type == 'online' else '/offline'}"
 
 
 async def _matching_subscriptions(
@@ -273,6 +281,33 @@ async def unsubscribe_to_user(username: str) -> bool:
     return True
 
 
-def expected_callbacks() -> set[str]:
-    """The callbacks a subscription must use to reach this deployment."""
-    return {_callback_url("online"), _callback_url("offline")}
+def subscription_target(subscription: Subscription) -> str:
+    """Whichever id identifies this subscription, since the field varies by type."""
+    condition = subscription.condition
+    for label, value in (
+        ("broadcaster", condition.broadcaster_user_id),
+        ("to broadcaster", condition.to_broadcaster_user_id),
+        ("from broadcaster", condition.from_broadcaster_user_id),
+        ("user", condition.user_id),
+    ):
+        if value:
+            return f"{label} {value}"
+    return f"id {subscription.id}"
+
+
+def undeliverable(subscription: Subscription) -> str | None:
+    """Why this subscription will not reach the bot, or None when it will.
+
+    Two things are checkable without knowing which event types the bot expects,
+    and only two: Twitch having disabled it, and a callback pointing elsewhere.
+    Matching whole URLs instead would call every event type the bot does not
+    create itself — chat, follows, raids — undeliverable on every start. The
+    case this cannot see, a callback on the right host with a wrong path, fails
+    its deliveries until Twitch disables it, which the first check then catches.
+    """
+    if subscription.status != "enabled":
+        return subscription.status
+    callback = subscription.transport.callback or ""
+    if not callback.startswith(callback_prefix()):
+        return f"calling back on {callback or 'nothing'}"
+    return None


### PR DESCRIPTION
The startup check matched callbacks against the two stream.* URLs, which are the only ones _subscribe creates. The bot serves seven webhook routes, and chat, follow, ad break, raid and moderate are registered outside the bot, so every one of them was reported as undeliverable on every start. The first message the admin channel ever showed was six false alarms, which is how a channel stops being read.

The check is a prefix now. All seven routes live under /webhook/twitch, so a callback that does not begin there belongs to another deployment or to this one before it moved, and a route added later needs no change here. The case a prefix cannot see, a wrong path on the right host, fails its deliveries until Twitch disables it, which the status check then catches.

Twitch keys a raid on to_/from_broadcaster rather than broadcaster_user_id, so a raid subscription reported itself as "broadcaster None".

## Summary by Sourcery

Correct Twitch subscription health checks to recognize all webhook routes served by the deployment and accurately identify affected subscriptions.

Bug Fixes:
- Stop healthy Twitch subscriptions on webhook routes outside the stream online/offline pair from being incorrectly reported as undeliverable at startup.
- Report raid and other subscription targets using the condition fields appropriate to each event type instead of showing a missing broadcaster identifier.

Enhancements:
- Centralize Twitch webhook callback validation around the deployment’s webhook path prefix while preserving path-boundary checks and disabled-subscription detection.
- Improve startup diagnostics with subscription-specific delivery failure reasons and targets.