### PR TITLE
Refactor/audit log module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,10 +156,22 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
   passes them in. The welcome and goodbye embeds are deliberately not entries —
   they go to `welcome`, and they are announcements to members rather than a record
   for staff.
-- **Every field value an audit entry builds is truncated and non-empty.** Discord
-  rejects both an empty value and one over 1024 characters, and a rejected send
-  costs the whole entry. Two separate bugs of this shape were fixed at once: an
-  unbounded recovered message, and a message edited down to no text.
+- **No audit entry can build a value Discord will reject.** Capping happens in
+  `_cap`, reached from `_embed` (description, 4096), `_field` (field value, 1024
+  and non-empty) and both author helpers (256), so a call site cannot produce one
+  by forgetting. This is enforced rather than documented because the documented
+  version was false: four separate values were outside it, and the worst — a
+  member's roles at 43 mentions — cost the entry *and* the row deletion queued
+  after it, leaving a departed member in Postgres for good. Footers are bounded by
+  construction, being ids and fixed text.
+- **What a person wrote is escaped; what the bot wrote is not.** `_said` for a
+  person's words, `_named` for a name going into a description, `_quoted` for
+  content that may instead be the bot's not-found marker. The distinction is not
+  cosmetic: a description and a field value both render masked links, so an
+  unescaped message can put a label of its choosing on a URL of its choosing in
+  front of whoever reads the audit log. An **author line** and a **footer** are
+  plain text to Discord and are deliberately left alone, which is why a name is
+  escaped in one place on an entry and not the other.
 - **Everything the bot says about itself goes through `errors.py`.** `report(exc,
   context)` for an exception, `notify(text)` for anything else worth the admin
   channel, `notify_soon(text)` for the two synchronous renderers that cannot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,19 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
   `init/bot_init.py` and `views/` import services lazily to break cycles. Leave them.
 - **`token_manager` and `shoutout_queue` are singletons** (`__new__`). Import the
   instance; do not construct another.
+- **Everything in the audit channel goes through `services/audit.py`.** One entry
+  point per thing worth recording, each named for the event and taking the domain
+  objects it happened to; the module settles the colour, the author line, how many
+  embeds it takes and which channel it lands in. Nothing else may resolve
+  `config.channel("audit_logs")`. It touches no database: `cogs/events.py` gathers
+  the facts, including reading back a message the gateway cache has dropped, and
+  passes them in. The welcome and goodbye embeds are deliberately not entries —
+  they go to `welcome`, and they are announcements to members rather than a record
+  for staff.
+- **Every field value an audit entry builds is truncated and non-empty.** Discord
+  rejects both an empty value and one over 1024 characters, and a rejected send
+  costs the whole entry. Two separate bugs of this shape were fixed at once: an
+  unbounded recovered message, and a message edited down to no text.
 - **Everything the bot says about itself goes through `errors.py`.** `report(exc,
   context)` for an exception, `notify(text)` for anything else worth the admin
   channel, `notify_soon(text)` for the two synchronous renderers that cannot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,43 @@ its reason.
 <!-- verity-memory:preserve -->
 <!-- Add binding, hand-curated guidance here; it survives Verity regeneration. -->
 
+## Verity runs before the commit, never after
+
+`verity analyze` must come back clean **while the change is still uncommitted** —
+staged or unstaged, both count — and only then `git commit`.
+
+This is mechanical, not a preference. `getChangedFiles()` in the Verity CLI takes
+the union of `git diff --name-only HEAD`, `git diff --name-only --cached` and
+untracked files. Committed work is reached only through
+`.verity/.last-reviewed-sha`, which does not exist in this repo, and the fallback
+for that case looks back exactly one commit and only within 120 seconds of it
+being made. So on a clean tree `verity analyze` answers
+
+```json
+{"gate_decision":"PASS","systemMessage":"Verity: No analyzable files changed"}
+```
+
+which is a PASS that reviewed nothing, and reads exactly like a real one.
+
+The sequence for every commit:
+
+```sh
+git add <paths>
+verity analyze     # must not be a "No analyzable files changed" PASS
+git commit ...     # only after it comes back clean
+```
+
+**A PASS whose message says nothing was analyzed does not count as a gate.** That
+message has two causes and they need telling apart: the change is already
+committed, or nothing in it is analyzable. `ANALYZABLE_EXTENSIONS` covers `.py`
+and the other source extensions but not `.md`, so a docs-only commit cannot be
+gated and will always answer this way — which is fine, but it must be reported as
+"not gated", never as a green gate. For anything touching `.py`, seeing this
+message means the reading was taken too late.
+
+The same applies to a whole branch: getting a real reading after the fact means
+uncommitting or re-running per commit, not quoting the empty PASS.
+
 ## Post-task reflection
 When a task is complete (you've created a PR, the user says "done" or "ship it",
 or the work is clearly finished), **draft the reflection yourself first** — 1–3

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,38 @@ running to greet it. It is rolled forward with a **notice** instead of a
 greeting, so nobody is wished a happy birthday on the wrong day.
 _Avoid_: missed birthday, overdue, expired
 
+### Audit log
+
+**Audit channel**:
+The Discord channel holding the **audit entries**, resolved by the slug
+`audit_logs`. Written only by `services/audit.py`. Not the **admin channel**:
+this one records what people did, that one records what the bot could not do.
+_Avoid_: mod log, staff channel, audit_logs (in prose)
+
+**Audit entry**:
+One recorded thing in the **audit channel**, written by one call to
+`services/audit.py`. An entry is not an embed — a deleted message that carried
+attachments is one entry and several embeds — and callers never learn which.
+_Avoid_: log line, audit message, event log
+
+**Person author**:
+An **audit entry**'s author line naming who the entry is about: their name,
+discriminator and avatar. The usual shape.
+_Avoid_: user header, byline
+
+**Caption author**:
+An **audit entry**'s author line naming the event instead of a person, used
+where no one person is its subject — a member joining, a ban, an invite. The
+distinction is internal; nothing outside `services/audit.py` chooses between
+them.
+_Avoid_: title, header, label
+
+**Recovered content**:
+The stored copy of a message the gateway cache no longer holds, read back from
+Postgres when one is edited or deleted. Unbounded, unlike a live message, so it
+is truncated before it can become a field.
+_Avoid_: cached content, old message, history
+
 ## Flagged ambiguities
 
 **`log_error` names two different behaviours.** Four files define it as
@@ -123,6 +155,12 @@ _Avoid_: missed birthday, overdue, expired
 the local logger and stop". Resolved: **report** is the only name for reaching
 the admin channel. Local logging is not a separate concept — every report logs
 locally first, and says so when it cannot go further.
+
+**"Audit log" names two different things.** Discord keeps one per guild, which
+the bot reads through `guild.audit_logs` to find out who deleted a message or
+cleared a channel. The bot also keeps its own, in the **audit channel**.
+Resolved: **audit entry** and **audit channel** are always the bot's; Discord's
+is always spelled out as "Discord's audit log".
 
 **"Alert" means the live alert, never an admin notice.** An admin-channel
 message about a failure is a **notice** or a **report**. Nothing else in this

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -142,6 +142,13 @@ distinction is internal; nothing outside `services/audit.py` chooses between
 them.
 _Avoid_: title, header, label
 
+**Their words**:
+The part of an **audit entry** a person wrote — a message, a nickname, an
+attempted command. Always escaped, because a description and a field value both
+render markdown; an **author line** and a footer are plain text and are left
+alone. The bot's own text is never escaped, so its formatting survives.
+_Avoid_: user input, raw content, unsafe text
+
 **Recovered content**:
 The stored copy of a message the gateway cache no longer holds, read back from
 Postgres when one is edited or deleted. Unbounded, unlike a live message, so it

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -330,9 +330,14 @@ class Events(Cog):
             await report(e, "Fatal error with on_invite_delete event")
 
     async def _get_message_content(self, message_id: int) -> str | None:
-        """None when nothing was stored, which is not the same as stored empty."""
+        """None when there is no row, which is not the same as a row storing "".
+
+        An attachment-only message is stored empty, and calling that a cache miss
+        both mislabels the delete and makes an edit that changed nothing look like
+        one that did.
+        """
         stored = await repository.get_message(message_id)
-        return stored.contents if stored and stored.contents else None
+        return stored.contents if stored is not None else None
 
 
 async def setup(bot: Bot) -> None:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,39 +1,29 @@
 import logging
-from typing import Literal
 
 import discord
 import pendulum
 from discord import (
     AllowedMentions,
-    CategoryChannel,
     Embed,
-    ForumChannel,
     Guild,
     Invite,
     Member,
     Message,
-    Object,
     RawBulkMessageDeleteEvent,
     RawMemberRemoveEvent,
     RawMessageDeleteEvent,
     RawMessageUpdateEvent,
-    Role,
-    StageChannel,
-    TextChannel,
-    Thread,
     User,
-    VoiceChannel,
 )
-from discord.abc import PrivateChannel
 from discord.ext.commands import Bot, Cog, CommandError, Context
 from discord.utils import escape_markdown
 from pendulum import DateTime
 
-from constants import DEFAULT_MISSING_CONTENT, UNKNOWN_USER
+from constants import DEFAULT_MISSING_CONTENT
 from db import repository
 from errors import report
 from services import (
-    get_age,
+    audit,
     get_channel_mention,
     get_discriminator,
     get_ordinal_suffix,
@@ -110,12 +100,12 @@ class Events(Cog):
     @Cog.listener()
     async def on_member_join(self, member: Member) -> None:
         try:
-            discriminator, url = await self._get_user_data(member)
+            url = get_pfp(member)
             embed = self._base_embed(
                 config.template("discord_welcome", mention=member.mention),
                 config.color("embed_color_welcome"),
             )
-            embed = self._set_author(embed, member.name, discriminator, url)
+            embed = self._set_author(embed, member.name, get_discriminator(member), url)
             embed = embed.set_footer(
                 text=f"{get_ordinal_suffix(member.guild.member_count)} member"
             ).set_image(url=url)
@@ -124,23 +114,7 @@ class Events(Cog):
                 config.channel("welcome"),
             )
 
-            age = get_age(pendulum.instance(member.created_at))
-            embed = self._base_embed(
-                f"{member.mention} {member.name}{discriminator}",
-                config.color("embed_color_join"),
-            )
-            embed = embed.set_author(
-                name=config.template("audit_member_joined"), icon_url=url
-            )
-            embed = (
-                embed.set_thumbnail(url=url)
-                .add_field(name="**Account Age**", value=age, inline=False)
-                .set_footer(text=f"ID: {member.id}")
-            )
-            await send_embed(
-                embed,
-                config.channel("audit_logs"),
-            )
+            await audit.member_joined(member)
 
             await self._safe_db_operation(
                 f"insert user {member.name} ({member.id})",
@@ -151,43 +125,23 @@ class Events(Cog):
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_member_join event")
 
-    async def _get_user_data(self, user: User | Member) -> tuple[str, str]:
-        return get_discriminator(user), get_pfp(user)
-
     @Cog.listener()
     async def on_raw_member_remove(self, payload: RawMemberRemoveEvent) -> None:
         try:
             member = payload.user
-            discriminator, url = await self._get_user_data(member)
+            url = get_pfp(member)
             embed = self._base_embed(
                 config.template("discord_goodbye", mention=member.mention),
                 config.color("embed_color_goodbye"),
             )
-            embed = self._set_author(embed, member.name, discriminator, url)
+            embed = self._set_author(embed, member.name, get_discriminator(member), url)
             embed = embed.set_image(url=url)
             await send_embed(
                 embed,
                 config.channel("welcome"),
             )
 
-            triple_nl = (
-                "" if isinstance(member, Member) and member.roles[1:] else "\n\n\n"
-            )
-            embed = self._base_embed(
-                f"{member.mention} {member.name}{discriminator}{triple_nl}",
-                config.color("embed_color_danger"),
-            )
-            embed = embed.set_author(
-                name=config.template("audit_member_left"), icon_url=url
-            )
-            embed = embed.set_thumbnail(url=url).set_footer(text=f"ID: {member.id}")
-            if isinstance(member, Member) and member.roles[1:]:
-                embed = embed.add_field(
-                    name="**Roles**",
-                    value=" ".join([f"{role.mention}" for role in member.roles[1:]]),
-                    inline=False,
-                )
-            await send_embed(embed, config.channel("audit_logs"))
+            await audit.member_left(member)
 
             await self._safe_db_operation(
                 f"remove user {member.name} ({member.id})",
@@ -221,64 +175,44 @@ class Events(Cog):
     @Cog.listener()
     async def on_member_update(self, before: Member, after: Member) -> None:
         try:
-            discriminator, url = await self._get_user_data(after)
+            if get_pfp(before) != get_pfp(after):
+                await audit.pfp_changed(after)
 
-            await self._handle_pfp_change(before, after, discriminator, url)
-            await self._handle_role_changes(before, after, discriminator, url)
-            await self._handle_nickname_change(before, after, discriminator, url)
-            await self._handle_timeout_changes(before, after, discriminator, url)
+            added = [role for role in after.roles if role not in before.roles]
+            removed = [role for role in before.roles if role not in after.roles]
+            if added:
+                await audit.role_added(after, added)
+            if removed:
+                await audit.role_removed(after, removed)
+
+            if before.nick != after.nick:
+                await audit.nickname_changed(
+                    after,
+                    before.name if before.nick is None else before.nick,
+                    after.name if after.nick is None else after.nick,
+                )
+
+            await self._handle_timeout_changes(before, after)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_member_update event")
 
-    async def _handle_pfp_change(
-        self, before: Member, after: Member, discriminator: str, url: str
-    ) -> None:
-        """Handle profile picture changes."""
-        before_url = get_pfp(before)
-        if url != before_url:
-            await self._log_pfp_change(after, discriminator, url)
-
-    async def _handle_role_changes(
-        self, before: Member, after: Member, discriminator: str, url: str
-    ) -> None:
-        """Handle role additions and removals."""
-        added = [role for role in after.roles if role not in before.roles]
-        removed = [role for role in before.roles if role not in after.roles]
-        if added:
-            await self._log_role_change(after, discriminator, url, added, True)
-        if removed:
-            await self._log_role_change(after, discriminator, url, removed, False)
-
-    async def _handle_nickname_change(
-        self, before: Member, after: Member, discriminator: str, url: str
-    ) -> None:
-        """Handle nickname changes."""
-        if before.nick != after.nick:
-            before_nick = before.name if before.nick is None else before.nick
-            after_nick = after.name if after.nick is None else after.nick
-            await self._log_nickname_change(
-                after, discriminator, url, before_nick, after_nick
-            )
-
-    async def _handle_timeout_changes(
-        self, before: Member, after: Member, discriminator: str, url: str
-    ) -> None:
-        """Handle timeout and untimeout events."""
-        before_timed_out_until = (
+    async def _handle_timeout_changes(self, before: Member, after: Member) -> None:
+        """A timeout that has already expired is not one, so both ends are compared."""
+        before_until = (
             pendulum.instance(before.timed_out_until)
             if before.timed_out_until
             else None
         )
-        after_timed_out_until = (
+        after_until = (
             pendulum.instance(after.timed_out_until) if after.timed_out_until else None
         )
-        before_timed_out = self._is_currently_timed_out(before_timed_out_until)
-        after_timed_out = self._is_currently_timed_out(after_timed_out_until)
+        was_timed_out = self._is_currently_timed_out(before_until)
+        is_timed_out = self._is_currently_timed_out(after_until)
 
-        if not before_timed_out and after_timed_out and after_timed_out_until:
-            await self._log_timeout(after, discriminator, url, after_timed_out_until)
-        elif before_timed_out and not after_timed_out:
-            await self._log_untimeout(after, discriminator, url)
+        if not was_timed_out and is_timed_out and after_until:
+            await audit.timed_out(after, after_until)
+        elif was_timed_out and not is_timed_out:
+            await audit.timeout_lifted(after)
 
     def _is_currently_timed_out(self, timeout_until: DateTime | None) -> bool:
         """Check if a member is currently timed out."""
@@ -300,36 +234,6 @@ class Events(Cog):
         except KeyError:
             return DEFAULT_MISSING_CONTENT
 
-    def _truncate_content(self, content: str, max_length: int = 1024) -> str:
-        """Truncate content if it exceeds the maximum length."""
-        if len(content) > max_length:
-            return f"{content[: max_length - 3]}..."
-        return content
-
-    async def _log_message_edit(
-        self,
-        after: Message,
-        before_content: str,
-        after_content: str,
-        discriminator: str,
-        url: str,
-    ) -> None:
-        """Log the message edit to the audit logs channel."""
-        channel_mention = get_channel_mention(after.channel)
-        message = f"**Message edited in {channel_mention}** [Jump to Message]({after.jump_url})"
-
-        before_content = self._truncate_content(before_content)
-        after_content = self._truncate_content(after_content)
-
-        embed = self._base_embed(message, config.color("embed_color_info"))
-        embed = self._set_author(embed, after.author.name, discriminator, url)
-        embed = (
-            embed.set_footer(text=f"User ID: {after.author.id}")
-            .add_field(name="**Before**", value=f"{before_content}", inline=False)
-            .add_field(name="**After**", value=f"{after_content}", inline=False)
-        )
-        await send_embed(embed, config.channel("audit_logs"))
-
     @Cog.listener()
     async def on_raw_message_edit(self, payload: RawMessageUpdateEvent) -> None:
         try:
@@ -339,20 +243,15 @@ class Events(Cog):
             before = payload.cached_message
             after = payload.message
 
-            discriminator, url = await self._get_user_data(after.author)
-
             if before and before.pinned != after.pinned:
-                await self._log_message_pin(after, discriminator, url)
+                await audit.pin_changed(after)
 
             before_content = await self._get_before_content(before, after.id)
-            after_content = after.content
 
-            if before_content == after_content:
+            if before_content == after.content:
                 return
 
-            await self._log_message_edit(
-                after, before_content, after_content, discriminator, url
-            )
+            await audit.message_edited(after, before_content)
             await self._store_message(after)
 
         except Exception as e:  # noqa: BLE001
@@ -370,21 +269,25 @@ class Events(Cog):
             user_who_deleted = await self._get_audit_user(
                 payload.guild_id, discord.AuditLogAction.message_delete
             )
-
             channel = self.bot.get_channel(payload.channel_id)
-
             message = payload.cached_message
-            if not message:
-                await self._log_deleted_missing_message(
-                    payload.message_id, user_who_deleted, channel
+
+            if message is None:
+                await audit.message_deleted_uncached(
+                    content=await self._get_message_content(payload.message_id),
+                    message_id=payload.message_id,
+                    deleted_by=user_who_deleted,
+                    channel=channel,
                 )
-                return
-
-            author = message.author
-
-            await self._log_message_delete(
-                message, payload.message_id, author, user_who_deleted, channel
-            )
+            else:
+                await audit.message_deleted(
+                    content=await self._deleted_content(message, payload.message_id),
+                    attachments=message.attachments,
+                    message_id=payload.message_id,
+                    author=message.author,
+                    deleted_by=user_who_deleted,
+                    channel=channel,
+                )
 
             await self._safe_db_operation(
                 f"delete message {payload.message_id}",
@@ -393,6 +296,13 @@ class Events(Cog):
             )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_message_delete event")
+
+    async def _deleted_content(self, message: Message, message_id: int) -> str:
+        """Reading .content off a cached message raises when discord.py has evicted it."""
+        try:
+            return message.content
+        except KeyError:
+            return await self._get_message_content(message_id)
 
     @Cog.listener()
     async def on_raw_bulk_message_delete(
@@ -403,22 +313,11 @@ class Events(Cog):
                 payload.guild_id, discord.AuditLogAction.message_bulk_delete
             )
 
-            channel_mention = get_channel_mention(
-                self.bot.get_channel(payload.channel_id)
+            await audit.bulk_deleted(
+                count=len(payload.message_ids),
+                deleted_by=user_who_deleted,
+                channel=self.bot.get_channel(payload.channel_id),
             )
-            description = f"**Bulk Delete in {channel_mention}, {len(payload.message_ids)} messages deleted**"
-
-            if user_who_deleted is None:
-                discriminator = ""
-                url = None
-                user_who_deleted_name = UNKNOWN_USER
-            else:
-                discriminator, url = await self._get_user_data(user_who_deleted)
-                user_who_deleted_name = user_who_deleted.name
-
-            embed = self._base_embed(description, config.color("embed_color_info"))
-            embed = self._set_author(embed, user_who_deleted_name, discriminator, url)
-            await send_embed(embed, config.channel("audit_logs"))
 
             for message_id in payload.message_ids:
                 await self._safe_db_operation(
@@ -429,64 +328,31 @@ class Events(Cog):
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_bulk_message_delete event")
 
-    async def _log_ban_unban(
-        self, user: User | Member, action: Literal["ban", "unban"]
-    ) -> None:
-        discriminator, url = await self._get_user_data(user)
-        embed = self._base_embed(
-            f"{user.mention} {user.name}{discriminator}",
-            config.color("embed_color_danger")
-            if action == "ban"
-            else config.color("embed_color_info"),
-        )
-        embed = embed.set_author(name=f"User {action.capitalize()}ed", icon_url=url)
-        embed = embed.set_thumbnail(url=url).set_footer(text=f"ID: {user.id}")
-        await send_embed(embed, config.channel("audit_logs"))
-
     @Cog.listener()
     async def on_member_ban(self, guild: Guild, user: User | Member) -> None:
         try:
-            await self._log_ban_unban(user, "ban")
+            await audit.banned(user)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_member_ban event")
 
     @Cog.listener()
     async def on_member_unban(self, guild: Guild, user: User | Member) -> None:
         try:
-            await self._log_ban_unban(user, "unban")
+            await audit.unbanned(user)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_member_unban event")
 
     @Cog.listener()
     async def on_invite_create(self, invite: Invite) -> None:
         try:
-            guild_name, guild_icon = await self._get_guild_name_and_icon_from_invite(
-                invite
-            )
-            channel_mention = get_channel_mention(invite.channel)
-            inviter_mention = f" by {invite.inviter.mention}" if invite.inviter else ""
-            expiry = (
-                f"<t:{int(invite.expires_at.timestamp())}:R>"
-                if invite.expires_at
-                else "Never"
-            )
-            description = f"**Invite [{invite.code}]({invite.url}) to {channel_mention} created{inviter_mention}**\nExpires: {expiry}"
-            embed = self._base_embed(description, config.color("embed_color_info"))
-            embed = embed.set_author(name=f"{guild_name}", icon_url=guild_icon)
-            await send_embed(embed, config.channel("audit_logs"))
+            await audit.invite_created(invite)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_invite_create event")
 
     @Cog.listener()
     async def on_invite_delete(self, invite: Invite) -> None:
         try:
-            guild_name, guild_icon = await self._get_guild_name_and_icon_from_invite(
-                invite
-            )
-            description = f"**Invite [{invite.code}]({invite.url}) deleted**"
-            embed = self._base_embed(description, config.color("embed_color_danger"))
-            embed = embed.set_author(name=f"{guild_name}", icon_url=guild_icon)
-            await send_embed(embed, config.channel("audit_logs"))
+            await audit.invite_deleted(invite)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_invite_delete event")
 
@@ -495,230 +361,6 @@ class Events(Cog):
         if stored and stored.contents:
             return stored.contents
         return DEFAULT_MISSING_CONTENT
-
-    async def _log_role_change(
-        self, member: Member, discriminator: str, url: str, roles: list[Role], add: bool
-    ) -> None:
-        roles_str = " ".join([role.mention for role in roles])
-        message = f"**{member.mention} was {'given' if add else 'removed from'} the role{'' if len(roles) == 1 else 's'} {roles_str}**"
-        embed = self._base_embed(message, config.color("embed_color_info"))
-        embed = self._set_author(embed, member.name, discriminator, url)
-        embed = embed.set_footer(text=f"ID: {member.id}")
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_nickname_change(
-        self, member: Member, discriminator: str, url: str, before: str, after: str
-    ) -> None:
-        embed = self._base_embed(
-            config.template("audit_nickname_changed", mention=member.mention),
-            config.color("embed_color_info"),
-        )
-        embed = self._set_author(embed, member.name, discriminator, url)
-        embed = (
-            embed.set_footer(text=f"ID: {member.id}")
-            .add_field(name="**Before**", value=f"{before}", inline=False)
-            .add_field(name="**After**", value=f"{after}", inline=False)
-        )
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_pfp_change(
-        self, member: Member, discriminator: str, url: str
-    ) -> None:
-        embed = self._base_embed(
-            config.template("audit_pfp_changed", mention=member.mention),
-            config.color("embed_color_info"),
-        )
-        embed = self._set_author(embed, member.name, discriminator, url)
-        embed = embed.set_thumbnail(url=url).set_footer(text=f"ID: {member.id}")
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_timeout(
-        self, member: Member, discriminator: str, url: str, timeout: DateTime
-    ) -> None:
-        expiry = f"<t:{int(timeout.timestamp())}:R>"
-        embed = self._base_embed(
-            config.template("audit_timed_out", mention=member.mention, expiry=expiry),
-            config.color("embed_color_info"),
-        )
-        embed = self._set_author(embed, member.name, discriminator, url)
-        embed = embed.set_footer(text=f"ID: {member.id}")
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_untimeout(
-        self, member: Member, discriminator: str, url: str
-    ) -> None:
-        embed = self._base_embed(
-            config.template("audit_timeout_removed", mention=member.mention),
-            config.color("embed_color_info"),
-        )
-        embed = self._set_author(embed, member.name, discriminator, url)
-        embed = embed.set_footer(text=f"ID: {member.id}")
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_message_pin(
-        self, message: Message, discriminator: str, url: str
-    ) -> None:
-        channel_mention = get_channel_mention(message.channel)
-        description = f"**Message {'pinned' if message.pinned else 'unpinned'} in {channel_mention}** [Jump to Message]({message.jump_url})"
-        embed = self._base_embed(description, config.color("embed_color_info"))
-        embed = self._set_author(embed, message.author.name, discriminator, url)
-        embed = embed.set_footer(text=f"User ID: {message.author.id}")
-        await send_embed(
-            embed,
-            config.channel("audit_logs"),
-        )
-
-    async def _log_deleted_missing_message(
-        self,
-        message_id: int,
-        user: User | Member | None,
-        channel: (
-            VoiceChannel
-            | StageChannel
-            | ForumChannel
-            | TextChannel
-            | CategoryChannel
-            | Thread
-            | PrivateChannel
-            | None
-        ),
-    ) -> None:
-        # A recovered message has no upper bound, unlike a live one; a field is 1024.
-        message_content = self._truncate_content(
-            await self._get_message_content(message_id)
-        )
-
-        if user is None:
-            discriminator = ""
-            url = None
-            user_mention = UNKNOWN_USER
-            user_name = UNKNOWN_USER
-            user_id = "Unknown ID"
-        else:
-            discriminator, url = await self._get_user_data(user)
-            user_mention = user.mention
-            user_name = user.name
-            user_id = user.id
-
-        channel_mention = get_channel_mention(channel)
-        description = f"**Message deleted by {user_mention} in {channel_mention}**"
-        embed = self._base_embed(description, config.color("embed_color_danger"))
-        embed = self._set_author(embed, user_name, discriminator, url)
-        embed = embed.add_field(
-            name="**Message**", value=f"{message_content}", inline=False
-        ).set_footer(text=f"Deleter: {user_id} | Message ID: {message_id}")
-        await send_embed(embed, config.channel("audit_logs"))
-
-        await self._safe_db_operation(
-            f"delete message {message_id}",
-            repository.delete_message,
-            message_id,
-        )
-
-    async def _log_message_delete(
-        self,
-        message: Message,
-        message_id: int,
-        author: User | Member,
-        user_who_deleted: User | Member | None,
-        channel: (
-            VoiceChannel
-            | StageChannel
-            | ForumChannel
-            | TextChannel
-            | CategoryChannel
-            | Thread
-            | PrivateChannel
-            | None
-        ),
-    ) -> None:
-        try:
-            message_content = message.content
-        except KeyError:
-            message_content = await self._get_message_content(message_id)
-
-        user_who_deleted_mention = (
-            "" if user_who_deleted is None else f" by {user_who_deleted.mention}"
-        )
-        channel_mention = get_channel_mention(channel)
-        description = f"**Message sent by {author.mention} deleted{user_who_deleted_mention} in {channel_mention}**"
-        discriminator, url = await self._get_user_data(author)
-        embed = self._base_embed(description, config.color("embed_color_danger"))
-        embed = self._set_author(embed, author.name, discriminator, url)
-        embed = embed.set_footer(text=f"Author: {author.id} | Message ID: {message_id}")
-        if message_content:
-            message_content = self._truncate_content(message_content)
-            embed = embed.add_field(
-                name="**Message**", value=f"{message_content}", inline=False
-            )
-        await send_embed(embed, config.channel("audit_logs"))
-        await self._log_message_attachments_delete(
-            message, message_id, author, channel, discriminator, url
-        )
-
-    async def _log_message_attachments_delete(
-        self,
-        message: Message,
-        message_id: int,
-        author: User | Member,
-        channel: (
-            VoiceChannel
-            | StageChannel
-            | ForumChannel
-            | TextChannel
-            | CategoryChannel
-            | Thread
-            | PrivateChannel
-            | None
-        ),
-        discriminator: str,
-        url: str,
-    ) -> None:
-        if message.attachments:
-            channel_mention = get_channel_mention(channel)
-            for attachment in message.attachments:
-                embed = self._base_embed(
-                    config.template(
-                        "audit_attachment_deleted",
-                        mention=author.mention,
-                        channel=channel_mention,
-                    ),
-                    config.color("embed_color_danger"),
-                )
-                embed = self._set_author(embed, author.name, discriminator, url)
-                embed = embed.set_footer(
-                    text=f"Author: {author.id} | Message ID: {message_id}"
-                ).set_image(url=attachment.url)
-                await send_embed(embed, config.channel("audit_logs"))
-
-    async def _get_guild_name_and_icon_from_invite(
-        self, invite: Invite
-    ) -> tuple[str, str | None]:
-        guild = invite.guild
-        guild_name = (
-            guild.name if guild and not isinstance(guild, Object) else "Unknown Guild"
-        )
-        guild_icon = (
-            guild.icon.url
-            if guild and not isinstance(guild, Object) and guild.icon
-            else None
-        )
-        return guild_name, guild_icon
 
 
 async def setup(bot: Bot) -> None:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -581,7 +581,10 @@ class Events(Cog):
             | None
         ),
     ) -> None:
-        message_content = await self._get_message_content(message_id)
+        # A recovered message has no upper bound, unlike a live one; a field is 1024.
+        message_content = self._truncate_content(
+            await self._get_message_content(message_id)
+        )
 
         if user is None:
             discriminator = ""

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -3,7 +3,6 @@ import logging
 import discord
 import pendulum
 from discord import (
-    AllowedMentions,
     Embed,
     Guild,
     Invite,
@@ -16,7 +15,6 @@ from discord import (
     User,
 )
 from discord.ext.commands import Bot, Cog, CommandError, Context
-from discord.utils import escape_markdown
 from pendulum import DateTime
 
 from constants import DEFAULT_MISSING_CONTENT
@@ -24,12 +22,10 @@ from db import repository
 from errors import report
 from services import (
     audit,
-    get_channel_mention,
     get_discriminator,
     get_ordinal_suffix,
     get_pfp,
     send_embed,
-    send_message,
 )
 from services.config import config
 
@@ -154,21 +150,7 @@ class Events(Cog):
     @Cog.listener()
     async def on_command_error(self, ctx: Context, error: CommandError) -> None:
         try:
-            channel_mention = get_channel_mention(ctx.channel)
-            # Both of these carry whatever the user typed, and this lands in a
-            # staff channel: escaped so it cannot forge formatting, and sent
-            # without the power to mention.
-            attempted = escape_markdown(ctx.message.content)
-            reason = escape_markdown(str(error))
-            message = (
-                f"Command not found: {attempted}\n"
-                f"Sent by: {ctx.author.mention} in {channel_mention}\n{reason}"
-            )
-            await send_message(
-                message,
-                config.channel("audit_logs"),
-                allowed_mentions=AllowedMentions.none(),
-            )
+            await audit.command_failed(ctx, error)
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_command_error event")
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,4 +1,4 @@
-import logging
+from collections.abc import Awaitable, Callable
 
 import discord
 import pendulum
@@ -17,7 +17,6 @@ from discord import (
 from discord.ext.commands import Bot, Cog, CommandError, Context
 from pendulum import DateTime
 
-from constants import DEFAULT_MISSING_CONTENT
 from db import repository
 from errors import report
 from services import (
@@ -29,14 +28,18 @@ from services import (
 )
 from services.config import config
 
-logger = logging.getLogger(__name__)
-
 
 class Events(Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
-    async def _safe_db_operation(self, operation: str, func, *args, **kwargs) -> None:
+    async def _safe_db_operation(
+        self,
+        operation: str,
+        func: Callable[..., Awaitable[object]],
+        *args: object,
+        **kwargs: object,
+    ) -> None:
         """Run a database write, reporting failures instead of raising."""
         try:
             await func(*args, **kwargs)
@@ -207,15 +210,6 @@ class Events(Cog):
             and payload.cached_message.author == self.bot.user
         )
 
-    async def _get_before_content(self, before: Message | None, message_id: int) -> str:
-        """Get the content of the message before editing."""
-        try:
-            if before:
-                return before.content
-            return await self._get_message_content(message_id)
-        except KeyError:
-            return DEFAULT_MISSING_CONTENT
-
     @Cog.listener()
     async def on_raw_message_edit(self, payload: RawMessageUpdateEvent) -> None:
         try:
@@ -228,7 +222,11 @@ class Events(Cog):
             if before and before.pinned != after.pinned:
                 await audit.pin_changed(after)
 
-            before_content = await self._get_before_content(before, after.id)
+            # Message.content is a slot set in __init__, so reading it cannot
+            # raise; a payload without it fails inside discord.py before dispatch.
+            before_content = (
+                before.content if before else await self._get_message_content(after.id)
+            )
 
             if before_content == after.content:
                 return
@@ -263,7 +261,7 @@ class Events(Cog):
                 )
             else:
                 await audit.message_deleted(
-                    content=await self._deleted_content(message, payload.message_id),
+                    content=message.content,
                     attachments=message.attachments,
                     message_id=payload.message_id,
                     author=message.author,
@@ -278,13 +276,6 @@ class Events(Cog):
             )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_message_delete event")
-
-    async def _deleted_content(self, message: Message, message_id: int) -> str:
-        """Reading .content off a cached message raises when discord.py has evicted it."""
-        try:
-            return message.content
-        except KeyError:
-            return await self._get_message_content(message_id)
 
     @Cog.listener()
     async def on_raw_bulk_message_delete(
@@ -338,11 +329,10 @@ class Events(Cog):
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_invite_delete event")
 
-    async def _get_message_content(self, message_id: int) -> str:
+    async def _get_message_content(self, message_id: int) -> str | None:
+        """None when nothing was stored, which is not the same as stored empty."""
         stored = await repository.get_message(message_id)
-        if stored and stored.contents:
-            return stored.contents
-        return DEFAULT_MISSING_CONTENT
+        return stored.contents if stored and stored.contents else None
 
 
 async def setup(bot: Bot) -> None:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -4,6 +4,7 @@ from typing import Literal
 import discord
 import pendulum
 from discord import (
+    AllowedMentions,
     CategoryChannel,
     Embed,
     ForumChannel,
@@ -25,6 +26,7 @@ from discord import (
 )
 from discord.abc import PrivateChannel
 from discord.ext.commands import Bot, Cog, CommandError, Context
+from discord.utils import escape_markdown
 from pendulum import DateTime
 
 from constants import DEFAULT_MISSING_CONTENT, UNKNOWN_USER
@@ -197,9 +199,24 @@ class Events(Cog):
 
     @Cog.listener()
     async def on_command_error(self, ctx: Context, error: CommandError) -> None:
-        channel_mention = get_channel_mention(ctx.channel)
-        message = f"Command not found: {ctx.message.content}\nSent by: {ctx.author.mention} in {channel_mention}\n{error}"
-        await send_message(message, config.channel("audit_logs"))
+        try:
+            channel_mention = get_channel_mention(ctx.channel)
+            # Both of these carry whatever the user typed, and this lands in a
+            # staff channel: escaped so it cannot forge formatting, and sent
+            # without the power to mention.
+            attempted = escape_markdown(ctx.message.content)
+            reason = escape_markdown(str(error))
+            message = (
+                f"Command not found: {attempted}\n"
+                f"Sent by: {ctx.author.mention} in {channel_mention}\n{reason}"
+            )
+            await send_message(
+                message,
+                config.channel("audit_logs"),
+                allowed_mentions=AllowedMentions.none(),
+            )
+        except Exception as e:  # noqa: BLE001
+            await report(e, "Fatal error with on_command_error event")
 
     @Cog.listener()
     async def on_member_update(self, before: Member, after: Member) -> None:

--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,7 @@ COGS = ["cogs.admin", "cogs.birthday", "cogs.events", "cogs.tasks"]
 
 UNKNOWN_USER = "Unknown User"
 DEFAULT_MISSING_CONTENT = "`Message content not found in cache`"
+EMPTY_CONTENT = "`No text`"
 
 
 class Months(Enum):

--- a/constants.py
+++ b/constants.py
@@ -12,6 +12,7 @@ COGS = ["cogs.admin", "cogs.birthday", "cogs.events", "cogs.tasks"]
 UNKNOWN_USER = "Unknown User"
 DEFAULT_MISSING_CONTENT = "`Message content not found in cache`"
 EMPTY_CONTENT = "`No text`"
+UNNAMED_EVENT = "Audit entry"
 
 
 class Months(Enum):

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,3 +1,4 @@
+from . import audit
 from .helper.helper import (
     edit_embed,
     format_unit,
@@ -34,6 +35,7 @@ from .twitch.api import (
 from .twitch.commands import dispatch
 
 __all__ = [
+    "audit",
     "dispatch",
     "edit_embed",
     "format_unit",

--- a/services/audit.py
+++ b/services/audit.py
@@ -27,6 +27,8 @@ from discord import (
     VoiceChannel,
 )
 from discord.abc import PrivateChannel
+from discord.ext.commands import CommandError, Context
+from discord.utils import escape_markdown
 from pendulum import DateTime
 
 from constants import EMPTY_CONTENT, UNKNOWN_USER
@@ -338,4 +340,26 @@ async def bulk_deleted(
         "embed_color_info",
     )
     _by(embed, deleted_by)
+    await _send(embed)
+
+
+async def command_failed(ctx: Context, error: CommandError) -> None:
+    """Named for the handler's real scope: not-found is only the reachable case.
+
+    Both values carry what the user typed, so both are escaped - a log entry
+    must not be able to forge formatting in the channel that records it.
+    """
+    embed = _embed(
+        f"**Command error in {get_channel_mention(ctx.channel)}**"
+        f" [Jump to Message]({ctx.message.jump_url})",
+        "embed_color_info",
+    )
+    _by(embed, ctx.author)
+    embed.set_footer(text=f"User ID: {ctx.author.id}").add_field(
+        name="**Command**",
+        value=_field(escape_markdown(ctx.message.content)),
+        inline=False,
+    ).add_field(
+        name="**Error**", value=_field(escape_markdown(str(error))), inline=False
+    )
     await _send(embed)

--- a/services/audit.py
+++ b/services/audit.py
@@ -12,26 +12,26 @@ from typing import Literal
 import pendulum
 from discord import (
     Attachment,
-    CategoryChannel,
     Embed,
-    ForumChannel,
     Invite,
     Member,
     Message,
     Object,
     Role,
-    StageChannel,
-    TextChannel,
     Thread,
     User,
-    VoiceChannel,
 )
-from discord.abc import PrivateChannel
+from discord.abc import GuildChannel, PrivateChannel
 from discord.ext.commands import CommandError, Context
 from discord.utils import escape_markdown
 from pendulum import DateTime
 
-from constants import EMPTY_CONTENT, UNKNOWN_USER
+from constants import (
+    DEFAULT_MISSING_CONTENT,
+    EMPTY_CONTENT,
+    UNKNOWN_USER,
+    UNNAMED_EVENT,
+)
 from services.config import config
 from services.helper.helper import (
     get_age,
@@ -41,50 +41,86 @@ from services.helper.helper import (
     send_embed,
 )
 
-# What bot.get_channel hands back, which is what the message events carry.
-AuditChannel = (
-    VoiceChannel
-    | StageChannel
-    | ForumChannel
-    | TextChannel
-    | CategoryChannel
-    | Thread
-    | PrivateChannel
-    | None
-)
+# Exactly what bot.get_channel hands back, which is what the message events carry.
+AuditChannel = GuildChannel | Thread | PrivateChannel | None
 
+# Discord rejects the whole embed if any one of these is exceeded, so they are
+# enforced here rather than trusted to the callers.
 _FIELD_LIMIT = 1024
+_DESCRIPTION_LIMIT = 4096
+_AUTHOR_LIMIT = 256
 
 
-def _truncate(content: str) -> str:
-    if len(content) > _FIELD_LIMIT:
-        return f"{content[: _FIELD_LIMIT - 3]}..."
-    return content
+def _cap(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    cut = text[: limit - 3]
+    # An escape sequence cut in half leaves a lone backslash, which would eat the
+    # first character of the ellipsis.
+    if (len(cut) - len(cut.rstrip("\\"))) % 2:
+        cut = cut[:-1]
+    return f"{cut}..."
 
 
-def _field(content: str) -> str:
-    """Discord rejects an empty field value, and that costs the whole entry."""
-    return _truncate(content) or EMPTY_CONTENT
+def _field(value: str) -> str:
+    """A field value is rejected for being empty as well as for being too long."""
+    return _cap(value, _FIELD_LIMIT) or EMPTY_CONTENT
+
+
+def _said(text: str) -> str:
+    """Text a person wrote, going somewhere Discord renders markdown.
+
+    Escaped, not merely capped: a description or a field value renders a masked
+    link, so an unescaped message could put a label of its choosing on a URL of
+    its choosing in front of whoever reads the audit log.
+    """
+    return _field(escape_markdown(text))
+
+
+def _named(user: User | Member) -> str:
+    """Escaped: a description renders markdown where an author line does not, and
+    bot and unmigrated names are not held to the modern username charset."""
+    return f"{escape_markdown(user.name)}{get_discriminator(user)}"
+
+
+def _quoted(text: str | None) -> str:
+    """A person's words, or the bot's marker for words it no longer has.
+
+    Only the person's are escaped: the marker is the bot's own text and its
+    formatting is deliberate.
+    """
+    return DEFAULT_MISSING_CONTENT if text is None else _said(text)
 
 
 def _embed(description: str, color: str) -> Embed:
     return Embed(
-        description=description, color=config.color(color), timestamp=pendulum.now()
+        description=_cap(description, _DESCRIPTION_LIMIT),
+        color=config.color(color),
+        timestamp=pendulum.now(),
     )
 
 
-def _by(embed: Embed, user: User | Member | None) -> Embed:
-    """Author line naming a person. None is a deleter the audit log did not name."""
+def _by(embed: Embed, user: User | Member | None) -> None:
+    """Author line naming a person. None is a deleter the audit log did not name.
+
+    Discord renders an author name as plain text, so nothing here is escaped.
+    """
     if user is None:
-        return embed.set_author(name=UNKNOWN_USER, icon_url=None)
-    return embed.set_author(
-        name=f"{user.name}{get_discriminator(user)}", icon_url=get_pfp(user)
+        embed.set_author(name=UNKNOWN_USER, icon_url=None)
+        return
+    embed.set_author(
+        name=_cap(f"{user.name}{get_discriminator(user)}", _AUTHOR_LIMIT),
+        icon_url=get_pfp(user),
     )
 
 
-def _captioned(embed: Embed, text: str, icon: str | None) -> Embed:
-    """Author line naming the event instead of a person."""
-    return embed.set_author(name=text, icon_url=icon)
+def _captioned(embed: Embed, text: str, icon: str | None) -> None:
+    """Author line naming the event instead of a person.
+
+    The fallback is for a template row that has gone missing: config has already
+    said so, and an empty author name would lose the entry on top of that.
+    """
+    embed.set_author(name=_cap(text, _AUTHOR_LIMIT) or UNNAMED_EVENT, icon_url=icon)
 
 
 async def _send(embed: Embed) -> None:
@@ -94,13 +130,13 @@ async def _send(embed: Embed) -> None:
 async def member_joined(member: Member) -> None:
     url = get_pfp(member)
     embed = _embed(
-        f"{member.mention} {member.name}{get_discriminator(member)}",
+        f"{member.mention} {_named(member)}",
         "embed_color_join",
     )
     _captioned(embed, config.template("audit_member_joined"), url)
     embed.set_thumbnail(url=url).add_field(
         name="**Account Age**",
-        value=get_age(pendulum.instance(member.created_at)),
+        value=_field(get_age(pendulum.instance(member.created_at))),
         inline=False,
     ).set_footer(text=f"ID: {member.id}")
     await _send(embed)
@@ -113,7 +149,7 @@ async def member_left(user: User | Member) -> None:
     # embed keeps its height either way.
     padding = "" if roles else "\n\n\n"
     embed = _embed(
-        f"{user.mention} {user.name}{get_discriminator(user)}{padding}",
+        f"{user.mention} {_named(user)}{padding}",
         "embed_color_danger",
     )
     _captioned(embed, config.template("audit_member_left"), url)
@@ -121,7 +157,7 @@ async def member_left(user: User | Member) -> None:
     if roles:
         embed.add_field(
             name="**Roles**",
-            value=" ".join([f"{role.mention}" for role in roles]),
+            value=_field(" ".join([role.mention for role in roles])),
             inline=False,
         )
     await _send(embed)
@@ -130,7 +166,7 @@ async def member_left(user: User | Member) -> None:
 async def _ban_state(user: User | Member, action: Literal["ban", "unban"]) -> None:
     url = get_pfp(user)
     embed = _embed(
-        f"{user.mention} {user.name}{get_discriminator(user)}",
+        f"{user.mention} {_named(user)}",
         "embed_color_danger" if action == "ban" else "embed_color_info",
     )
     _captioned(embed, f"User {action.capitalize()}ed", url)
@@ -169,7 +205,7 @@ async def invite_created(invite: Invite) -> None:
         f" created{inviter_mention}**\nExpires: {expiry}",
         "embed_color_info",
     )
-    _captioned(embed, f"{guild_name}", guild_icon)
+    _captioned(embed, guild_name, guild_icon)
     await _send(embed)
 
 
@@ -178,7 +214,7 @@ async def invite_deleted(invite: Invite) -> None:
     embed = _embed(
         f"**Invite [{invite.code}]({invite.url}) deleted**", "embed_color_danger"
     )
-    _captioned(embed, f"{guild_name}", guild_icon)
+    _captioned(embed, guild_name, guild_icon)
     await _send(embed)
 
 
@@ -209,8 +245,8 @@ async def nickname_changed(member: Member, before: str, after: str) -> None:
     )
     _by(embed, member)
     embed.set_footer(text=f"ID: {member.id}").add_field(
-        name="**Before**", value=f"{_field(before)}", inline=False
-    ).add_field(name="**After**", value=f"{_field(after)}", inline=False)
+        name="**Before**", value=_said(before), inline=False
+    ).add_field(name="**After**", value=_said(after), inline=False)
     await _send(embed)
 
 
@@ -248,7 +284,7 @@ async def timeout_lifted(member: Member) -> None:
     await _send(embed)
 
 
-async def message_edited(after: Message, before_content: str) -> None:
+async def message_edited(after: Message, before_content: str | None) -> None:
     embed = _embed(
         f"**Message edited in {get_channel_mention(after.channel)}**"
         f" [Jump to Message]({after.jump_url})",
@@ -256,8 +292,8 @@ async def message_edited(after: Message, before_content: str) -> None:
     )
     _by(embed, after.author)
     embed.set_footer(text=f"User ID: {after.author.id}").add_field(
-        name="**Before**", value=f"{_field(before_content)}", inline=False
-    ).add_field(name="**After**", value=f"{_field(after.content)}", inline=False)
+        name="**Before**", value=_quoted(before_content), inline=False
+    ).add_field(name="**After**", value=_said(after.content), inline=False)
     await _send(embed)
 
 
@@ -294,7 +330,7 @@ async def message_deleted(
     _by(embed, author)
     embed.set_footer(text=footer)
     if content:
-        embed.add_field(name="**Message**", value=f"{_truncate(content)}", inline=False)
+        embed.add_field(name="**Message**", value=_said(content), inline=False)
     await _send(embed)
 
     for attachment in attachments:
@@ -313,7 +349,7 @@ async def message_deleted(
 
 async def message_deleted_uncached(
     *,
-    content: str,
+    content: str | None,
     message_id: int,
     deleted_by: User | Member | None,
     channel: AuditChannel,
@@ -327,7 +363,7 @@ async def message_deleted_uncached(
     )
     _by(embed, deleted_by)
     embed.add_field(
-        name="**Message**", value=f"{_truncate(content)}", inline=False
+        name="**Message**", value=_quoted(content), inline=False
     ).set_footer(text=f"Deleter: {deleter_id} | Message ID: {message_id}")
     await _send(embed)
 
@@ -357,9 +393,7 @@ async def command_failed(ctx: Context, error: CommandError) -> None:
     _by(embed, ctx.author)
     embed.set_footer(text=f"User ID: {ctx.author.id}").add_field(
         name="**Command**",
-        value=_field(escape_markdown(ctx.message.content)),
+        value=_said(ctx.message.content),
         inline=False,
-    ).add_field(
-        name="**Error**", value=_field(escape_markdown(str(error))), inline=False
-    )
+    ).add_field(name="**Error**", value=_said(str(error)), inline=False)
     await _send(embed)

--- a/services/audit.py
+++ b/services/audit.py
@@ -1,0 +1,336 @@
+"""The audit log: one entry point per thing worth recording.
+
+Callers say what happened and pass the domain objects it happened to. Everything
+else — which colour, which author line, whether it takes one embed or several,
+and which channel it lands in — is settled here, so a change to how the log
+looks is a change to one file.
+"""
+
+from collections.abc import Sequence
+from typing import Literal
+
+import pendulum
+from discord import (
+    Attachment,
+    CategoryChannel,
+    Embed,
+    ForumChannel,
+    Invite,
+    Member,
+    Message,
+    Object,
+    Role,
+    StageChannel,
+    TextChannel,
+    Thread,
+    User,
+    VoiceChannel,
+)
+from discord.abc import PrivateChannel
+from pendulum import DateTime
+
+from constants import UNKNOWN_USER
+from services.config import config
+from services.helper.helper import (
+    get_age,
+    get_channel_mention,
+    get_discriminator,
+    get_pfp,
+    send_embed,
+)
+
+# What bot.get_channel hands back, which is what the message events carry.
+AuditChannel = (
+    VoiceChannel
+    | StageChannel
+    | ForumChannel
+    | TextChannel
+    | CategoryChannel
+    | Thread
+    | PrivateChannel
+    | None
+)
+
+_FIELD_LIMIT = 1024
+
+
+def _truncate(content: str) -> str:
+    if len(content) > _FIELD_LIMIT:
+        return f"{content[: _FIELD_LIMIT - 3]}..."
+    return content
+
+
+def _embed(description: str, color: str) -> Embed:
+    return Embed(
+        description=description, color=config.color(color), timestamp=pendulum.now()
+    )
+
+
+def _by(embed: Embed, user: User | Member | None) -> Embed:
+    """Author line naming a person. None is a deleter the audit log did not name."""
+    if user is None:
+        return embed.set_author(name=UNKNOWN_USER, icon_url=None)
+    return embed.set_author(
+        name=f"{user.name}{get_discriminator(user)}", icon_url=get_pfp(user)
+    )
+
+
+def _captioned(embed: Embed, text: str, icon: str | None) -> Embed:
+    """Author line naming the event instead of a person."""
+    return embed.set_author(name=text, icon_url=icon)
+
+
+async def _send(embed: Embed) -> None:
+    await send_embed(embed, config.channel("audit_logs"))
+
+
+async def member_joined(member: Member) -> None:
+    url = get_pfp(member)
+    embed = _embed(
+        f"{member.mention} {member.name}{get_discriminator(member)}",
+        "embed_color_join",
+    )
+    _captioned(embed, config.template("audit_member_joined"), url)
+    embed.set_thumbnail(url=url).add_field(
+        name="**Account Age**",
+        value=get_age(pendulum.instance(member.created_at)),
+        inline=False,
+    ).set_footer(text=f"ID: {member.id}")
+    await _send(embed)
+
+
+async def member_left(user: User | Member) -> None:
+    url = get_pfp(user)
+    roles = user.roles[1:] if isinstance(user, Member) else []
+    # The blank lines stand in for the roles field when there is none, so the
+    # embed keeps its height either way.
+    padding = "" if roles else "\n\n\n"
+    embed = _embed(
+        f"{user.mention} {user.name}{get_discriminator(user)}{padding}",
+        "embed_color_danger",
+    )
+    _captioned(embed, config.template("audit_member_left"), url)
+    embed.set_thumbnail(url=url).set_footer(text=f"ID: {user.id}")
+    if roles:
+        embed.add_field(
+            name="**Roles**",
+            value=" ".join([f"{role.mention}" for role in roles]),
+            inline=False,
+        )
+    await _send(embed)
+
+
+async def _ban_state(user: User | Member, action: Literal["ban", "unban"]) -> None:
+    url = get_pfp(user)
+    embed = _embed(
+        f"{user.mention} {user.name}{get_discriminator(user)}",
+        "embed_color_danger" if action == "ban" else "embed_color_info",
+    )
+    _captioned(embed, f"User {action.capitalize()}ed", url)
+    embed.set_thumbnail(url=url).set_footer(text=f"ID: {user.id}")
+    await _send(embed)
+
+
+async def banned(user: User | Member) -> None:
+    await _ban_state(user, "ban")
+
+
+async def unbanned(user: User | Member) -> None:
+    await _ban_state(user, "unban")
+
+
+def _guild_of(invite: Invite) -> tuple[str, str | None]:
+    guild = invite.guild
+    name = guild.name if guild and not isinstance(guild, Object) else "Unknown Guild"
+    icon = (
+        guild.icon.url
+        if guild and not isinstance(guild, Object) and guild.icon
+        else None
+    )
+    return name, icon
+
+
+async def invite_created(invite: Invite) -> None:
+    guild_name, guild_icon = _guild_of(invite)
+    channel_mention = get_channel_mention(invite.channel)
+    inviter_mention = f" by {invite.inviter.mention}" if invite.inviter else ""
+    expiry = (
+        f"<t:{int(invite.expires_at.timestamp())}:R>" if invite.expires_at else "Never"
+    )
+    embed = _embed(
+        f"**Invite [{invite.code}]({invite.url}) to {channel_mention}"
+        f" created{inviter_mention}**\nExpires: {expiry}",
+        "embed_color_info",
+    )
+    _captioned(embed, f"{guild_name}", guild_icon)
+    await _send(embed)
+
+
+async def invite_deleted(invite: Invite) -> None:
+    guild_name, guild_icon = _guild_of(invite)
+    embed = _embed(
+        f"**Invite [{invite.code}]({invite.url}) deleted**", "embed_color_danger"
+    )
+    _captioned(embed, f"{guild_name}", guild_icon)
+    await _send(embed)
+
+
+async def _role_change(member: Member, roles: list[Role], added: bool) -> None:
+    roles_str = " ".join([role.mention for role in roles])
+    embed = _embed(
+        f"**{member.mention} was {'given' if added else 'removed from'}"
+        f" the role{'' if len(roles) == 1 else 's'} {roles_str}**",
+        "embed_color_info",
+    )
+    _by(embed, member)
+    embed.set_footer(text=f"ID: {member.id}")
+    await _send(embed)
+
+
+async def role_added(member: Member, roles: list[Role]) -> None:
+    await _role_change(member, roles, added=True)
+
+
+async def role_removed(member: Member, roles: list[Role]) -> None:
+    await _role_change(member, roles, added=False)
+
+
+async def nickname_changed(member: Member, before: str, after: str) -> None:
+    embed = _embed(
+        config.template("audit_nickname_changed", mention=member.mention),
+        "embed_color_info",
+    )
+    _by(embed, member)
+    embed.set_footer(text=f"ID: {member.id}").add_field(
+        name="**Before**", value=f"{before}", inline=False
+    ).add_field(name="**After**", value=f"{after}", inline=False)
+    await _send(embed)
+
+
+async def pfp_changed(member: Member) -> None:
+    embed = _embed(
+        config.template("audit_pfp_changed", mention=member.mention),
+        "embed_color_info",
+    )
+    _by(embed, member)
+    embed.set_thumbnail(url=get_pfp(member)).set_footer(text=f"ID: {member.id}")
+    await _send(embed)
+
+
+async def timed_out(member: Member, until: DateTime) -> None:
+    embed = _embed(
+        config.template(
+            "audit_timed_out",
+            mention=member.mention,
+            expiry=f"<t:{int(until.timestamp())}:R>",
+        ),
+        "embed_color_info",
+    )
+    _by(embed, member)
+    embed.set_footer(text=f"ID: {member.id}")
+    await _send(embed)
+
+
+async def timeout_lifted(member: Member) -> None:
+    embed = _embed(
+        config.template("audit_timeout_removed", mention=member.mention),
+        "embed_color_info",
+    )
+    _by(embed, member)
+    embed.set_footer(text=f"ID: {member.id}")
+    await _send(embed)
+
+
+async def message_edited(after: Message, before_content: str) -> None:
+    embed = _embed(
+        f"**Message edited in {get_channel_mention(after.channel)}**"
+        f" [Jump to Message]({after.jump_url})",
+        "embed_color_info",
+    )
+    _by(embed, after.author)
+    embed.set_footer(text=f"User ID: {after.author.id}").add_field(
+        name="**Before**", value=f"{_truncate(before_content)}", inline=False
+    ).add_field(name="**After**", value=f"{_truncate(after.content)}", inline=False)
+    await _send(embed)
+
+
+async def pin_changed(message: Message) -> None:
+    embed = _embed(
+        f"**Message {'pinned' if message.pinned else 'unpinned'} in"
+        f" {get_channel_mention(message.channel)}**"
+        f" [Jump to Message]({message.jump_url})",
+        "embed_color_info",
+    )
+    _by(embed, message.author)
+    embed.set_footer(text=f"User ID: {message.author.id}")
+    await _send(embed)
+
+
+async def message_deleted(
+    *,
+    content: str,
+    attachments: Sequence[Attachment],
+    message_id: int,
+    author: User | Member,
+    deleted_by: User | Member | None,
+    channel: AuditChannel,
+) -> None:
+    """One embed for the message, then one more for each attachment it carried."""
+    channel_mention = get_channel_mention(channel)
+    deleter = "" if deleted_by is None else f" by {deleted_by.mention}"
+    footer = f"Author: {author.id} | Message ID: {message_id}"
+
+    embed = _embed(
+        f"**Message sent by {author.mention} deleted{deleter} in {channel_mention}**",
+        "embed_color_danger",
+    )
+    _by(embed, author)
+    embed.set_footer(text=footer)
+    if content:
+        embed.add_field(name="**Message**", value=f"{_truncate(content)}", inline=False)
+    await _send(embed)
+
+    for attachment in attachments:
+        embed = _embed(
+            config.template(
+                "audit_attachment_deleted",
+                mention=author.mention,
+                channel=channel_mention,
+            ),
+            "embed_color_danger",
+        )
+        _by(embed, author)
+        embed.set_footer(text=footer).set_image(url=attachment.url)
+        await _send(embed)
+
+
+async def message_deleted_uncached(
+    *,
+    content: str,
+    message_id: int,
+    deleted_by: User | Member | None,
+    channel: AuditChannel,
+) -> None:
+    """A deletion the bot has no copy of the message for, only the stored text."""
+    mention = UNKNOWN_USER if deleted_by is None else deleted_by.mention
+    deleter_id = "Unknown ID" if deleted_by is None else deleted_by.id
+    embed = _embed(
+        f"**Message deleted by {mention} in {get_channel_mention(channel)}**",
+        "embed_color_danger",
+    )
+    _by(embed, deleted_by)
+    embed.add_field(
+        name="**Message**", value=f"{_truncate(content)}", inline=False
+    ).set_footer(text=f"Deleter: {deleter_id} | Message ID: {message_id}")
+    await _send(embed)
+
+
+async def bulk_deleted(
+    *, count: int, deleted_by: User | Member | None, channel: AuditChannel
+) -> None:
+    embed = _embed(
+        f"**Bulk Delete in {get_channel_mention(channel)}, {count} messages deleted**",
+        "embed_color_info",
+    )
+    _by(embed, deleted_by)
+    await _send(embed)

--- a/services/audit.py
+++ b/services/audit.py
@@ -29,7 +29,7 @@ from discord import (
 from discord.abc import PrivateChannel
 from pendulum import DateTime
 
-from constants import UNKNOWN_USER
+from constants import EMPTY_CONTENT, UNKNOWN_USER
 from services.config import config
 from services.helper.helper import (
     get_age,
@@ -58,6 +58,11 @@ def _truncate(content: str) -> str:
     if len(content) > _FIELD_LIMIT:
         return f"{content[: _FIELD_LIMIT - 3]}..."
     return content
+
+
+def _field(content: str) -> str:
+    """Discord rejects an empty field value, and that costs the whole entry."""
+    return _truncate(content) or EMPTY_CONTENT
 
 
 def _embed(description: str, color: str) -> Embed:
@@ -202,8 +207,8 @@ async def nickname_changed(member: Member, before: str, after: str) -> None:
     )
     _by(embed, member)
     embed.set_footer(text=f"ID: {member.id}").add_field(
-        name="**Before**", value=f"{before}", inline=False
-    ).add_field(name="**After**", value=f"{after}", inline=False)
+        name="**Before**", value=f"{_field(before)}", inline=False
+    ).add_field(name="**After**", value=f"{_field(after)}", inline=False)
     await _send(embed)
 
 
@@ -249,8 +254,8 @@ async def message_edited(after: Message, before_content: str) -> None:
     )
     _by(embed, after.author)
     embed.set_footer(text=f"User ID: {after.author.id}").add_field(
-        name="**Before**", value=f"{_truncate(before_content)}", inline=False
-    ).add_field(name="**After**", value=f"{_truncate(after.content)}", inline=False)
+        name="**Before**", value=f"{_field(before_content)}", inline=False
+    ).add_field(name="**After**", value=f"{_field(after.content)}", inline=False)
     await _send(embed)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Centralize and harden audit logging by routing all recorded events through a dedicated service.

New Features:
- Add a centralized audit service with dedicated entry points for member, message, moderation, invite, and command events.
- Recover uncached deleted-message content from persisted message records and preserve attachment deletions as part of a single audit event.

Bug Fixes:
- Prevent malformed Discord embeds by consistently bounding descriptions, fields, author names, and empty values.
- Escape user-authored content in audit entries to prevent unintended Markdown and masked-link rendering.
- Distinguish missing persisted message content from legitimately empty messages.

Enhancements:
- Move audit-entry construction out of the events cog so channel routing, formatting, authorship, and embed composition are managed consistently in one service.
- Simplify event handlers to gather event facts and delegate audit recording while retaining database cleanup and timeout detection.

Documentation:
- Document audit-channel ownership, audit-entry terminology, content escaping, embed limits, and the required pre-commit Verity analysis workflow.

Chores:
- Add constants for empty message content and unnamed audit events.