### PR TITLE
Refactor/split twitch controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ is gitignored, so a fresh clone has none of it — `VERITY.md` has the restore s
 **One process wearing two faces.** `main.py` is a FastAPI app, and the Discord bot
 is not the entrypoint: the lifespan handler starts `main()` as a background task,
 which loads `constants.COGS` and calls `bot.start()`. Twitch never connects to the
-bot — it delivers EventSub webhooks over HTTP to the router in `controller/twitch.py`.
+bot — it delivers EventSub webhooks over HTTP to the router in `controller/twitch.py`,
+which verifies and parses them and hands each to `services/twitch/events.py`.
 Stop the web server and the bot goes with it.
 
 **Startup order is spread across three files.** lifespan (`main.py`) → cog loading →
@@ -93,6 +94,14 @@ flows. Both request `twitch_app_scopes`; the callbacks validate the returned
 Twitch user ID, client ID and scopes before upserting `oauth_token`. The `app`
 row is separate, uses client credentials and has no refresh token.
 
+**Three files, three jobs, none of them over the threshold.**
+`controller/twitch.py` receives a signed notification, verifies it, parses it and
+hands it on. `services/twitch/events.py` says what each event makes the bot do —
+it lives under `services/` because it names no HTTP type at all, and nothing
+under `services/` imports `controller/`. `controller/twitch_oauth.py` carries the
+two authorization-code flows on their own router; it shares nothing with the
+webhook controller, not the signature check, the models, or the path prefix.
+
 **A webhook route's model says which event it serves.** Each `*Subscription`
 declares its own `type` as a `Literal`, so a payload for the wrong event fails to
 parse instead of being compared against a string passed in beside it, and the
@@ -100,6 +109,18 @@ shared base carries no `type` at all — a mutable `str` there could not be narr
 to a `Literal` soundly. `process_webhook` is generic in the model, which binds it
 to its handler: pairing `StreamOnlineEventSub` with the follow handler stops
 type-checking, where before both parameters were unannotated and so `Any`.
+
+**A signed delivery is also checked for freshness, and dispatched at most once.**
+A timestamp more than ten minutes from now in either direction is refused with a
+403 — Twitch's own guidance for replay, and a clock ahead is as wrong as one
+behind. A message id that has already reached a handler answers 202 without
+dispatching again, since Twitch says a notification may arrive twice and 202 is
+what stops the retries. Only ids that were *dispatched* are remembered, so a
+delivery Twitch retries because this end failed still gets through. The set is
+process-local, which is enough and not a compromise: the Discord gateway
+connection lives in this process, so a second replica would double every bot
+action. The one cost is real — if the host clock drifts past ten minutes every
+event is refused, loudly, until it is fixed.
 
 **A signed request that the models reject answers 4xx, not 5xx.** Twitch retries a
 5xx, and a payload rejected once is rejected identically every time, so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,17 +117,26 @@ behind. A message id that has already reached a handler answers 202 without
 dispatching again, since Twitch says a notification may arrive twice and 202 is
 what stops the retries. Only ids that were *dispatched* are remembered, so a
 delivery Twitch retries because this end failed still gets through. The set is
-process-local, which is enough and not a compromise: the Discord gateway
-connection lives in this process, so a second replica would double every bot
-action. The one cost is real — if the host clock drifts past ten minutes every
-event is refused, loudly, until it is fixed.
+process-local, and remembered for twice the freshness window: a clock further
+out than one window refuses everything anyway, so the skew that could open a gap
+between the two cannot exceed a window. It holds 20,000 ids, which the chat route
+would otherwise fill in minutes — one id per chat line — and reaching the cap
+says so in the admin channel, because past it a redelivery can run twice.
 
-**A signed request that the models reject answers 4xx, not 5xx.** Twitch retries a
-5xx, and a payload rejected once is rejected identically every time, so the
-retries only spend the subscription's failure budget before Twitch disables it. A
-body that is not JSON, is not a JSON object, or does not match the route's model
-is a 400 with a notice. Only something genuinely unexpected is a 500 with a
-report.
+The cost of the freshness check is real and worse than "events are refused". A
+403 is a failed delivery, and enough of them revoke the subscription — of which
+five of the seven cannot be recreated from this repo. That is why the check sits
+*below* the verification handshake and applies to notifications alone: a wrong
+clock must not also refuse the resubscribe that repairs it.
+
+**A signed request that the models reject answers 4xx, not 5xx.** A body that is
+not JSON, is not a JSON object, or does not match the route's model is a 400 with
+a notice naming the field that failed; only something genuinely unexpected is a
+500 with a report. The reason is that a payload this end cannot read is not a
+server fault, and a traceback for one is noise — *not* that it saves retries.
+Twitch documents no 4xx/5xx distinction anywhere, and revocation counts anything
+that is not a 2xx, so a 400 spends the failure budget exactly as a 500 does. That
+wrong justification was recorded here first; do not restore it.
 
 **Only two of the seven EventSub subscriptions can be created from this repo.**
 `/subscribe` creates `stream.online` and `stream.offline`. Chat, follow, ad break,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,28 @@ flows. Both request `twitch_app_scopes`; the callbacks validate the returned
 Twitch user ID, client ID and scopes before upserting `oauth_token`. The `app`
 row is separate, uses client credentials and has no refresh token.
 
+**A webhook route's model says which event it serves.** Each `*Subscription`
+declares its own `type` as a `Literal`, so a payload for the wrong event fails to
+parse instead of being compared against a string passed in beside it, and the
+shared base carries no `type` at all — a mutable `str` there could not be narrowed
+to a `Literal` soundly. `process_webhook` is generic in the model, which binds it
+to its handler: pairing `StreamOnlineEventSub` with the follow handler stops
+type-checking, where before both parameters were unannotated and so `Any`.
+
+**A signed request that the models reject answers 4xx, not 5xx.** Twitch retries a
+5xx, and a payload rejected once is rejected identically every time, so the
+retries only spend the subscription's failure budget before Twitch disables it. A
+body that is not JSON, is not a JSON object, or does not match the route's model
+is a 400 with a notice. Only something genuinely unexpected is a 500 with a
+report.
+
+**Only two of the seven EventSub subscriptions can be created from this repo.**
+`/subscribe` creates `stream.online` and `stream.offline`. Chat, follow, ad break,
+raid and moderate are provisioned outside it, so a deployment whose public URL
+changes leaves five subscriptions pointing at a dead callback with nothing here
+able to recreate them. The startup check notices an undeliverable subscription;
+it cannot repair these five.
+
 **A live alert is closed by its updater, never by a webhook.** `stream.offline`
 carries no stream id, so the handler cannot tell which stream ended; it calls
 `live_alert.wake()`, and the updater re-checks Helix and stops if it has been

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ a finding. Declarations are budgeted per session and every one is recorded with
 its reason.
 
 <!-- verity-memory:preserve -->
+
 <!-- Add binding, hand-curated guidance here; it survives Verity regeneration. -->
 
 ## Verity runs before the commit, never after

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The bookworm tags are frozen at an old uv whose newest 3.14 cannot satisfy
 # requires-python, so this follows trixie instead.
-FROM ghcr.io/astral-sh/uv:0.12.7-python3.14-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.12.10-python3.14-trixie-slim
 
 WORKDIR /app
 
@@ -12,7 +12,8 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_PYTHON_PREFERENCE=only-system
 
 # The official image ships loclx statically linked, so this needs no apt-get.
-COPY --from=localxpose/localxpose:latest /ko-app/loclx /usr/local/bin/loclx
+# Pinned by digest, not tag: this is 24.9.2, which the digest cannot say itself.
+COPY --from=localxpose/localxpose@sha256:013ec01336c6444688853c8afeb9fe45dc35199ccb9de9f9c61f266af99d0158 /ko-app/loclx /usr/local/bin/loclx
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project

--- a/controller/__init__.py
+++ b/controller/__init__.py
@@ -1,3 +1,4 @@
 from .twitch import twitch_router
+from .twitch_oauth import twitch_oauth_router
 
-__all__ = ["twitch_router"]
+__all__ = ["twitch_oauth_router", "twitch_router"]

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -56,8 +56,22 @@ _MESSAGE_WINDOW_SECONDS = 600
 # worked does not run it twice. Process-local is enough and not a compromise:
 # the Discord gateway connection lives in this process, so a second replica
 # would double every bot action.
-_HANDLED_LIMIT = 1024
+#
+# Twice the freshness window, and that is provably enough rather than a guess:
+# freshness is measured on the wall clock and this on the monotonic one, so a
+# host clock behind Twitch's would leave a gap where a delivery is still fresh
+# but no longer remembered - except that a clock more than one window out
+# refuses everything as stale anyway, so the usable skew cannot exceed a window.
+_HANDLED_TTL_SECONDS = _MESSAGE_WINDOW_SECONDS * 2
+
+# A safety valve, not the eviction policy; the TTL is. The chat route claims one
+# id per chat line, so the old 1024 was reached at under two lines a second and
+# then forgot ids inside their own window, which is precisely a redelivery being
+# handled twice. Reaching even this says the traffic broke the assumption, so it
+# is counted and said out loud rather than silently dropping the oldest.
+_HANDLED_LIMIT = 20_000
 _handled: OrderedDict[str, float] = OrderedDict()
+_forgotten_early = 0
 
 
 def _is_stale(sent: pendulum.DateTime) -> bool:
@@ -67,11 +81,11 @@ def _is_stale(sent: pendulum.DateTime) -> bool:
 def _claim(message_id: str) -> bool:
     """Take this delivery, or say that something already has it.
 
-    Claiming and checking are one step: there is an await between here and the
-    dispatch, so two copies of one delivery could otherwise both get past a
-    check that only looked.
+    Checking and taking are one step so that adding an await between them later
+    cannot let two copies of one delivery both past a check that only looked.
     """
-    cutoff = time.monotonic() - _MESSAGE_WINDOW_SECONDS
+    global _forgotten_early
+    cutoff = time.monotonic() - _HANDLED_TTL_SECONDS
     while _handled and next(iter(_handled.values())) < cutoff:
         _handled.popitem(last=False)
     if message_id in _handled:
@@ -79,7 +93,21 @@ def _claim(message_id: str) -> bool:
     _handled[message_id] = time.monotonic()
     while len(_handled) > _HANDLED_LIMIT:
         _handled.popitem(last=False)
+        _forgotten_early += 1
     return True
+
+
+async def _report_forgotten(endpoint: str) -> None:
+    """Say so when the cap bit, because then a redelivery can be handled twice."""
+    global _forgotten_early
+    if not _forgotten_early:
+        return
+    dropped, _forgotten_early = _forgotten_early, 0
+    await notify(
+        f"Replay cache full on {endpoint}: {dropped} delivery id(s) forgotten"
+        f" inside their window, so a redelivery of one could run twice.",
+        key="replay-cache-full",
+    )
 
 
 def _release(message_id: str) -> None:
@@ -142,25 +170,6 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
         await notify(f"403: Forbidden request on {endpoint}. Signature does not match.")
         raise HTTPException(status_code=403)
 
-    # Only after the signature matched: an unauthenticated caller must not be
-    # able to raise a notice by sending a stale timestamp.
-    try:
-        sent = parse_rfc3339(headers.get(TWITCH_MESSAGE_TIMESTAMP, ""))
-    except ValueError:
-        logger.warning("403: Unreadable message timestamp on %s", endpoint)
-        await notify(f"403: Forbidden request on {endpoint}. Unreadable timestamp.")
-        raise HTTPException(status_code=403) from None
-
-    if _is_stale(sent):
-        logger.warning("403: Stale delivery on %s, sent %s", endpoint, sent)
-        await notify(
-            f"403: Forbidden request on {endpoint}. Timestamp outside the"
-            f" {_MESSAGE_WINDOW_SECONDS}s window, which is also what a wrong"
-            f" clock on this host looks like.",
-            key=f"stale-delivery:{endpoint}",
-        )
-        raise HTTPException(status_code=403)
-
     message_type = headers.get(TWITCH_MESSAGE_TYPE, "").lower()
     try:
         parsed = await request.json()
@@ -198,6 +207,29 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
         )
         return Response(status_code=204)
 
+    # Freshness applies to notifications alone, and deliberately sits below the
+    # handshake. A wrong clock refusing events is recoverable; a wrong clock that
+    # also refuses webhook_callback_verification would block the resubscribe that
+    # repairs it, and five of the seven subscriptions cannot be recreated from
+    # this repo at all.
+    try:
+        sent = parse_rfc3339(headers.get(TWITCH_MESSAGE_TIMESTAMP, ""))
+    except ValueError:
+        logger.warning("403: Unreadable message timestamp on %s", endpoint)
+        await notify(f"403: Forbidden request on {endpoint}. Unreadable timestamp.")
+        raise HTTPException(status_code=403) from None
+
+    if _is_stale(sent):
+        logger.warning("403: Stale delivery on %s, sent %s", endpoint, sent)
+        await notify(
+            f"403: Forbidden request on {endpoint}. Timestamp outside the"
+            f" {_MESSAGE_WINDOW_SECONDS}s window, which is also what a wrong"
+            f" clock on this host looks like. Twitch counts this as a failed"
+            f" delivery, and enough of them revoke the subscription.",
+            key=f"stale-delivery:{endpoint}",
+        )
+        raise HTTPException(status_code=403)
+
 
 async def process_webhook[E: BaseModel](
     request: Request,
@@ -220,6 +252,15 @@ async def process_webhook[E: BaseModel](
         # Twitch says a notification may arrive twice. 202 rather than an error:
         # this end does have it, and saying so is what stops the retries.
         message_id = request.headers.get(TWITCH_MESSAGE_ID, "")
+        if not message_id:
+            # Twitch always sends one, and it is inside the HMAC. Refusing beats
+            # claiming "": that collapses every id-less delivery into one and
+            # throws the rest away saying nothing.
+            logger.warning("400: Delivery carried no message id on %s", endpoint)
+            await notify(f"400: Bad request on {endpoint}. No message id.")
+            raise HTTPException(status_code=400)
+
+        await _report_forgotten(endpoint)
         if not _claim(message_id):
             logger.info(
                 "Duplicate %s on %s, not dispatched again", message_id, endpoint
@@ -237,15 +278,26 @@ async def process_webhook[E: BaseModel](
     except HTTPException:
         raise
     except ValidationError as e:
-        # 4xx rather than 5xx deliberately: Twitch retries a 5xx, and a payload
-        # this model rejects will be rejected identically every time, so the
-        # retries only cost deliveries against the subscription's failure budget.
+        # 4xx rather than 5xx because a payload this end cannot read is not a
+        # server fault, and a full exception report for one is noise. Not for the
+        # reason first given here: Twitch documents no 4xx/5xx distinction at all,
+        # and revocation counts anything that is not a 2xx, so this spends the
+        # subscription's failure budget exactly as a 500 would.
+        # The field, not just the model: what this most often catches is this
+        # end's model falling behind Twitch's payload, and the name of the
+        # field that moved is the whole diagnosis.
+        where = "; ".join(
+            ".".join(str(part) for part in err["loc"]) for err in e.errors()[:3]
+        )
         logger.warning(
-            f"400: {event_model.__name__} rejected the payload on {endpoint}"
+            "400: %s rejected the payload on %s at %s",
+            event_model.__name__,
+            endpoint,
+            where,
         )
         await notify(
-            f"400: Bad request on {endpoint}."
-            f" Payload did not match {event_model.__name__}."
+            f"400: Bad request on {endpoint}. Payload did not match"
+            f" {event_model.__name__} at: {where}"
         )
         raise HTTPException(status_code=400) from e
     except Exception as e:

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -1,11 +1,11 @@
-import asyncio
 import logging
 import time
+from collections import OrderedDict
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+import pendulum
 from fastapi import APIRouter, HTTPException, Request, Response
-from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, ValidationError
 
 from background import fire_and_forget
@@ -16,7 +16,6 @@ from constants import (
     TWITCH_MESSAGE_SIGNATURE,
     TWITCH_MESSAGE_TIMESTAMP,
     TWITCH_MESSAGE_TYPE,
-    TokenType,
 )
 from errors import notify, report
 from models import (
@@ -25,47 +24,67 @@ from models import (
     ChannelFollowEventSub,
     ChannelModerateEventSub,
     ChannelRaidEventSub,
-    RefreshResponse,
-    Stream,
     StreamOfflineEventSub,
     StreamOnlineEventSub,
-    TokenValidationResponse,
 )
 from services import (
     get_hmac,
     get_hmac_message,
-    get_stream,
-    get_user,
+    parse_rfc3339,
     verify_message,
 )
-from services.config import config
-from services.helper.http_client import http_client_manager
-from services.twitch import live_alert, stream_session
-from services.twitch.chat import say, say_template
-from services.twitch.commands import dispatch
-from services.twitch.helix import HelixError
-from services.twitch.oauth import (
-    authorization_url,
-    callback_uri,
-    configured_scopes,
-    consume_authorization,
-    expected_user_id,
-)
-from services.twitch.token_manager import token_manager
+from services.twitch import events
 
 logger = logging.getLogger(__name__)
 
 twitch_router = APIRouter()
 
-# Twitch announces the stream before Helix lists it. Bounded by the clock rather
-# than by a count of attempts: a lookup that is timing out takes most of a minute
-# on its own, so thirty of those is a quarter of an hour, not thirty seconds.
-_STREAM_WAIT_SECONDS = 60
 
 # An EventSub payload is a few kilobytes. The whole body has to be read to
 # compute the signature over it, so it is counted as it arrives and abandoned
 # past this.
 _MAX_BODY_BYTES = 256 * 1024
+
+
+# Twitch's own guidance for replay: a delivery whose timestamp is far from now
+# is not one Twitch is sending, it is one somebody kept. Applied in both
+# directions, since a clock ahead is as wrong as a clock behind.
+_MESSAGE_WINDOW_SECONDS = 600
+
+# Ids of deliveries that reached a handler. Only those, so a delivery Twitch
+# retries because this end failed still gets through, while a retry of one that
+# worked does not run it twice. Process-local is enough and not a compromise:
+# the Discord gateway connection lives in this process, so a second replica
+# would double every bot action.
+_HANDLED_LIMIT = 1024
+_handled: OrderedDict[str, float] = OrderedDict()
+
+
+def _is_stale(sent: pendulum.DateTime) -> bool:
+    return abs((pendulum.now("UTC") - sent).total_seconds()) > _MESSAGE_WINDOW_SECONDS
+
+
+def _claim(message_id: str) -> bool:
+    """Take this delivery, or say that something already has it.
+
+    Claiming and checking are one step: there is an await between here and the
+    dispatch, so two copies of one delivery could otherwise both get past a
+    check that only looked.
+    """
+    cutoff = time.monotonic() - _MESSAGE_WINDOW_SECONDS
+    while _handled and next(iter(_handled.values())) < cutoff:
+        _handled.popitem(last=False)
+    if message_id in _handled:
+        return False
+    _handled[message_id] = time.monotonic()
+    while len(_handled) > _HANDLED_LIMIT:
+        _handled.popitem(last=False)
+    return True
+
+
+def _release(message_id: str) -> None:
+    """Give a claim back, so a delivery this end failed can still be retried."""
+    _handled.pop(message_id, None)
 
 
 async def _bounded_body(request: Request, endpoint: str) -> bytes:
@@ -123,6 +142,25 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
         await notify(f"403: Forbidden request on {endpoint}. Signature does not match.")
         raise HTTPException(status_code=403)
 
+    # Only after the signature matched: an unauthenticated caller must not be
+    # able to raise a notice by sending a stale timestamp.
+    try:
+        sent = parse_rfc3339(headers.get(TWITCH_MESSAGE_TIMESTAMP, ""))
+    except ValueError:
+        logger.warning("403: Unreadable message timestamp on %s", endpoint)
+        await notify(f"403: Forbidden request on {endpoint}. Unreadable timestamp.")
+        raise HTTPException(status_code=403) from None
+
+    if _is_stale(sent):
+        logger.warning("403: Stale delivery on %s, sent %s", endpoint, sent)
+        await notify(
+            f"403: Forbidden request on {endpoint}. Timestamp outside the"
+            f" {_MESSAGE_WINDOW_SECONDS}s window, which is also what a wrong"
+            f" clock on this host looks like.",
+            key=f"stale-delivery:{endpoint}",
+        )
+        raise HTTPException(status_code=403)
+
     message_type = headers.get(TWITCH_MESSAGE_TYPE, "").lower()
     try:
         parsed = await request.json()
@@ -142,8 +180,12 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
 
     if message_type == "webhook_callback_verification":
         challenge = body.get("challenge")
+        # text/plain explicitly: the value is echoed straight back, and nothing
+        # that reads the reply should be free to interpret it as markup.
         return Response(
-            challenge if isinstance(challenge, str) else "", status_code=200
+            challenge if isinstance(challenge, str) else "",
+            status_code=200,
+            media_type="text/plain",
         )
 
     if message_type == "revocation":
@@ -175,9 +217,22 @@ async def process_webhook[E: BaseModel](
         if validation:
             return validation
 
-        body: dict[str, Any] = await request.json()
-        event_sub = event_model.model_validate(body)
-        fire_and_forget(task_func(event_sub), name=endpoint)
+        # Twitch says a notification may arrive twice. 202 rather than an error:
+        # this end does have it, and saying so is what stops the retries.
+        message_id = request.headers.get(TWITCH_MESSAGE_ID, "")
+        if not _claim(message_id):
+            logger.info(
+                "Duplicate %s on %s, not dispatched again", message_id, endpoint
+            )
+            return Response(status_code=202)
+
+        try:
+            body: dict[str, Any] = await request.json()
+            event_sub = event_model.model_validate(body)
+            fire_and_forget(task_func(event_sub), name=endpoint)
+        except BaseException:
+            _release(message_id)
+            raise
         return Response(status_code=202)
     except HTTPException:
         raise
@@ -198,314 +253,13 @@ async def process_webhook[E: BaseModel](
         raise HTTPException(status_code=500) from e
 
 
-async def _wait_for_stream_info(
-    broadcaster_id: int,
-) -> tuple[Stream | None, HelixError | None]:
-    """Poll until Twitch admits the stream is up, tolerating a failed lookup.
-
-    Bounded, because Twitch delivers stream.online once and never again: waiting
-    forever and giving up both lose the alert, but only one of them says so. The
-    last lookup error comes back too, so giving up can tell "Twitch says they
-    are offline" from "Twitch could not be reached".
-    """
-    deadline = time.monotonic() + _STREAM_WAIT_SECONDS
-    last_error: HelixError | None = None
-
-    while True:
-        try:
-            stream_info = await get_stream(broadcaster_id)
-        except HelixError as e:
-            last_error = e
-            logger.warning(f"Stream lookup failed for {broadcaster_id}: {e}")
-            stream_info = None
-
-        if stream_info:
-            return stream_info, None
-        # Checked after the attempt, so a slow first lookup still gets its turn.
-        if time.monotonic() >= deadline:
-            return None, last_error
-        await asyncio.sleep(1)
-
-
-async def _stream_online_task(event_sub: StreamOnlineEventSub) -> None:
-    broadcaster_id = int(event_sub.event.broadcaster_user_id)
-    try:
-        stream_info, lookup_error = await _wait_for_stream_info(broadcaster_id)
-        if stream_info is None:
-            reason = (
-                f"the last lookup failed: {lookup_error}"
-                if lookup_error is not None
-                else "Twitch went on reporting them offline"
-            )
-            await notify(
-                f"Gave up after {_STREAM_WAIT_SECONDS}s waiting for Twitch to confirm"
-                f" broadcaster {broadcaster_id} is live, so no alert was posted and no"
-                f" stream session was started: {reason}",
-                key=f"stream-online-gave-up:{broadcaster_id}",
-            )
-            return
-
-        try:
-            user_info = await get_user(broadcaster_id)
-        except HelixError as e:
-            # Decoration. stream.online does not come again, so the alert must
-            # not depend on it.
-            await notify(
-                f"Announcing broadcaster {broadcaster_id} without their profile: {e}",
-                key=f"stream-online-profile:{broadcaster_id}",
-            )
-            user_info = None
-
-        is_main = stream_info.user_login == config.setting("broadcaster_username")
-        channel = (
-            config.channel("stream_alerts") if is_main else config.channel("promo")
-        )
-
-        # began does not raise: it guards each of its own chat lines, because
-        # the alert below must survive a Twitch that will not take a greeting.
-        await stream_session.began(broadcaster_id, stream_info)
-
-        await live_alert.announce(broadcaster_id, stream_info, user_info, channel)
-
-    except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in _stream_online_task for {broadcaster_id}")
-
-
-async def _stream_offline_task(event_sub: StreamOfflineEventSub) -> None:
-    broadcaster_id = int(event_sub.event.broadcaster_user_id)
-    try:
-        # The payload names no stream, so this handler cannot tell which one
-        # ended. It wakes the updater, which can. See docs/adr/0001.
-        await live_alert.wake(broadcaster_id)
-
-    except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in _stream_offline_task for {broadcaster_id}")
-
-
-async def _channel_chat_message_task(event_sub: ChannelChatMessageEventSub) -> None:
-    try:
-        if not event_sub.event.message.text.startswith("!"):
-            return
-        text_without_prefix = event_sub.event.message.text[1:]
-        command_parts = text_without_prefix.split(" ", 1)
-        command = command_parts[0].lower()
-        args = command_parts[1] if len(command_parts) > 1 else ""
-
-        if (
-            event_sub.event.source_broadcaster_user_id is not None
-            and event_sub.event.source_broadcaster_user_id
-            != event_sub.event.broadcaster_user_id
-        ):
-            return
-
-        await dispatch(event_sub, command, args)
-    except Exception as e:  # noqa: BLE001
-        await report(e, "Error processing Twitch chat webhook task")
-
-
-async def _channel_follow_task(event_sub: ChannelFollowEventSub) -> None:
-    try:
-        await say_template(
-            event_sub.event.broadcaster_user_id,
-            "twitch_follow_thanks",
-            user=event_sub.event.user_name,
-        )
-    except Exception as e:  # noqa: BLE001
-        await report(e, "Error processing Twitch follow webhook task")
-
-
-async def _channel_ad_break_begin_task(event_sub: ChannelAdBreakBeginEventSub) -> None:
-    broadcaster_id = event_sub.event.broadcaster_user_id
-    try:
-        ad_duration = event_sub.event.duration_seconds
-
-        # Each step stands alone: a dropped "ads starting" used to take the
-        # "ads over" message and the next break's warning down with it.
-        await say_template(
-            broadcaster_id, "twitch_ad_break_start", minutes=ad_duration // 60
-        )
-        await asyncio.sleep(ad_duration)
-        await say_template(broadcaster_id, "twitch_ad_break_end")
-
-        stream_session.schedule_ad_break_warning(broadcaster_id)
-    except Exception as e:  # noqa: BLE001
-        await report(e, "Error processing Twitch ad break webhook task")
-
-
-async def _validate_oauth_identity(
-    auth_response: RefreshResponse,
-    token_type: TokenType,
-    endpoint: str,
-) -> TokenValidationResponse:
-    response = await http_client_manager.request(
-        "GET",
-        "https://id.twitch.tv/oauth2/validate",
-        headers={"Authorization": f"OAuth {auth_response.access_token}"},
-    )
-    if response.status_code < 200 or response.status_code >= 300:
-        logger.error(
-            "OAuth token validation failed with status=%s", response.status_code
-        )
-        await notify(
-            f"Failed to validate the Twitch token from {endpoint}: "
-            f"{response.status_code} {response.text}"
-        )
-        raise HTTPException(status_code=500, detail="Twitch token validation failed")
-
-    validation = TokenValidationResponse.model_validate(response.json())
-    expected_id = expected_user_id(token_type)
-    missing_scopes = sorted(set(configured_scopes()) - set(validation.scopes))
-
-    problems = []
-    if validation.client_id != settings.twitch_client_id:
-        problems.append("the token belongs to a different Twitch application")
-    if validation.user_id != expected_id:
-        problems.append(
-            f"expected Twitch user ID {expected_id}, but {validation.login} "
-            f"authorized as ID {validation.user_id}"
-        )
-    if missing_scopes:
-        problems.append(f"missing scopes: {', '.join(missing_scopes)}")
-
-    if problems:
-        message = f"Rejected {token_type.value} authorization: {'; '.join(problems)}"
-        logger.warning(message)
-        await notify(message)
-        raise HTTPException(status_code=400, detail=message)
-    return validation
-
-
-async def _oauth_callback_common(
-    code: str | None,
-    state: str,
-    endpoint: str,
-    token_type: TokenType,
-    error: str | None,
-    error_description: str | None,
-) -> tuple[RefreshResponse, TokenValidationResponse]:
-    if not consume_authorization(token_type, state):
-        logger.warning("400: Bad request on %s. Invalid OAuth state.", endpoint)
-        await notify(f"400: Bad request on {endpoint}. Invalid or expired OAuth state.")
-        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
-
-    if error:
-        detail = error_description or error
-        logger.warning("Twitch authorization denied on %s: %s", endpoint, detail)
-        raise HTTPException(
-            status_code=400, detail=f"Twitch authorization denied: {detail}"
-        )
-    if not code:
-        raise HTTPException(status_code=400, detail="Missing Twitch authorization code")
-
-    params = {
-        "client_id": settings.twitch_client_id,
-        "client_secret": settings.twitch_client_secret,
-        "code": code,
-        "grant_type": "authorization_code",
-        "redirect_uri": callback_uri(token_type),
-    }
-    response = await http_client_manager.request(
-        "POST", "https://id.twitch.tv/oauth2/token", data=params
-    )
-
-    if response.status_code < 200 or response.status_code >= 300:
-        logger.error(
-            f"Token exchange failed with status={response.status_code}, response={response.text}"
-        )
-        await notify(
-            f"Failed to exchange token: {response.status_code} {response.text}"
-        )
-        raise HTTPException(status_code=500)
-
-    auth_response = RefreshResponse.model_validate(response.json())
-    if auth_response.token_type != "bearer":
-        logger.error(
-            f"Token exchange failed: unexpected token type {auth_response.token_type}"
-        )
-        await notify(
-            f"Failed to exchange token: unexpected token type {auth_response.token_type}"
-        )
-        raise HTTPException(status_code=500)
-    validation = await _validate_oauth_identity(auth_response, token_type, endpoint)
-    return auth_response, validation
-
-
-@twitch_router.get("/twitch/oauth/start/{identity}")
-async def twitch_oauth_start(identity: str, state: str) -> Response:
-    try:
-        token_type = TokenType(identity)
-        return RedirectResponse(authorization_url(token_type, state), status_code=302)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from None
-
-
-@twitch_router.get("/twitch/oauth/callback")
-async def twitch_oauth_callback(
-    state: str,
-    code: str | None = None,
-    error: str | None = None,
-    error_description: str | None = None,
-) -> Response:
-    try:
-        auth_response, validation = await _oauth_callback_common(
-            code,
-            state,
-            "/twitch/oauth/callback",
-            TokenType.User,
-            error,
-            error_description,
-        )
-        await token_manager.set_user_access_token(auth_response)
-        return Response(
-            f"Authorization successful for bot account {validation.login} "
-            f"({validation.user_id}). You can close this tab.",
-            status_code=200,
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        await report(e, "500: Internal server error on /twitch/oauth/callback")
-        raise HTTPException(status_code=500) from e
-
-
-@twitch_router.get("/twitch/oauth/callback/broadcaster")
-async def twitch_oauth_callback_broadcaster(
-    state: str,
-    code: str | None = None,
-    error: str | None = None,
-    error_description: str | None = None,
-) -> Response:
-    try:
-        auth_response, validation = await _oauth_callback_common(
-            code,
-            state,
-            "/twitch/oauth/callback/broadcaster",
-            TokenType.Broadcaster,
-            error,
-            error_description,
-        )
-        await token_manager.set_broadcaster_access_token(auth_response)
-        return Response(
-            f"Authorization successful for broadcaster account {validation.login} "
-            f"({validation.user_id}). You can close this tab.",
-            status_code=200,
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        await report(
-            e, "500: Internal server error on /twitch/oauth/callback/broadcaster"
-        )
-        raise HTTPException(status_code=500) from e
-
-
 @twitch_router.post("/webhook/twitch")
 async def stream_online_webhook(request: Request) -> Response:
     return await process_webhook(
         request,
         "/webhook/twitch",
         StreamOnlineEventSub,
-        _stream_online_task,
+        events.stream_online,
     )
 
 
@@ -515,7 +269,7 @@ async def stream_offline_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/offline",
         StreamOfflineEventSub,
-        _stream_offline_task,
+        events.stream_offline,
     )
 
 
@@ -525,7 +279,7 @@ async def channel_chat_message_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/chat",
         ChannelChatMessageEventSub,
-        _channel_chat_message_task,
+        events.channel_chat_message,
     )
 
 
@@ -535,7 +289,7 @@ async def channel_follow_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/follow",
         ChannelFollowEventSub,
-        _channel_follow_task,
+        events.channel_follow,
     )
 
 
@@ -545,30 +299,8 @@ async def channel_ad_break_begin_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/adbreak",
         ChannelAdBreakBeginEventSub,
-        _channel_ad_break_begin_task,
+        events.channel_ad_break_begin,
     )
-
-
-async def _channel_raid_task(event_sub: ChannelRaidEventSub) -> None:
-    try:
-        if stream_session.is_main_broadcaster(event_sub.event.from_broadcaster_user_id):
-            twitch_url = (
-                f"https://www.twitch.tv/{event_sub.event.to_broadcaster_user_login}"
-            )
-            await say_template(
-                event_sub.event.from_broadcaster_user_id,
-                "twitch_raid_out",
-                name=event_sub.event.to_broadcaster_user_name,
-                url=twitch_url,
-            )
-        elif stream_session.is_main_broadcaster(event_sub.event.to_broadcaster_user_id):
-            await say(
-                event_sub.event.to_broadcaster_user_id,
-                f"!so {event_sub.event.from_broadcaster_user_login}",
-                "the incoming raid shoutout",
-            )
-    except Exception as e:  # noqa: BLE001
-        await report(e, "Error processing Twitch raid webhook task")
 
 
 @twitch_router.post("/webhook/twitch/raid")
@@ -577,19 +309,8 @@ async def channel_raid_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/raid",
         ChannelRaidEventSub,
-        _channel_raid_task,
+        events.channel_raid,
     )
-
-
-async def _channel_moderate_task(event_sub: ChannelModerateEventSub) -> None:
-    try:
-        if event_sub.event.action != "raid" or not stream_session.is_main_broadcaster(
-            event_sub.event.broadcaster_user_id
-        ):
-            return
-        await say_template(event_sub.event.broadcaster_user_id, "twitch_raid_farewell")
-    except Exception as e:  # noqa: BLE001
-        await report(e, "Error processing Twitch moderate webhook task")
 
 
 @twitch_router.post("/webhook/twitch/moderate")
@@ -598,5 +319,5 @@ async def channel_moderate_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/moderate",
         ChannelModerateEventSub,
-        _channel_moderate_task,
+        events.channel_moderate,
     )

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
 import time
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, ValidationError
 
 from background import fire_and_forget
 from config import settings
@@ -122,14 +124,31 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
         raise HTTPException(status_code=403)
 
     message_type = headers.get(TWITCH_MESSAGE_TYPE, "").lower()
-    body: dict[str, Any] = await request.json()
+    try:
+        parsed = await request.json()
+    except ValueError as e:
+        # The signature already matched, so this is Twitch sending something
+        # unparseable rather than an intruder. 4xx because the retry would carry
+        # the same bytes and fail the same way.
+        logger.warning("400: Body is not JSON on %s", endpoint)
+        await notify(f"400: Bad request on {endpoint}. Body is not JSON.")
+        raise HTTPException(status_code=400) from e
+
+    if not isinstance(parsed, dict):
+        logger.warning("400: Body is not a JSON object on %s", endpoint)
+        await notify(f"400: Bad request on {endpoint}. Body is not a JSON object.")
+        raise HTTPException(status_code=400)
+    body: dict[str, Any] = parsed
 
     if message_type == "webhook_callback_verification":
-        challenge = body.get("challenge", "")
-        return Response(challenge or "", status_code=200)
+        challenge = body.get("challenge")
+        return Response(
+            challenge if isinstance(challenge, str) else "", status_code=200
+        )
 
     if message_type == "revocation":
-        subscription: dict[str, Any] = body.get("subscription", {})
+        raw = body.get("subscription")
+        subscription: dict[str, Any] = raw if isinstance(raw, dict) else {}
         await notify(
             f"Revoked {subscription.get('type', 'unknown')} notifications for"
             f" condition: {subscription.get('condition', {})} because"
@@ -138,9 +157,19 @@ async def validate_call(request: Request, endpoint: str) -> Response | None:
         return Response(status_code=204)
 
 
-async def process_webhook(
-    request: Request, endpoint: str, event_model, expected_type: str, task_func
+async def process_webhook[E: BaseModel](
+    request: Request,
+    endpoint: str,
+    event_model: type[E],
+    task_func: Callable[[E], Coroutine[Any, Any, None]],
 ) -> Response:
+    """Validate, parse and dispatch one EventSub notification.
+
+    The type parameter ties a route's model to its handler, so a pair that
+    disagree stops type-checking; both were unannotated, and therefore Any.
+    Which event the route serves is asserted by the model itself, whose
+    subscription type is a Literal.
+    """
     try:
         validation = await validate_call(request, endpoint)
         if validation:
@@ -148,17 +177,22 @@ async def process_webhook(
 
         body: dict[str, Any] = await request.json()
         event_sub = event_model.model_validate(body)
-        if event_sub.subscription.type != expected_type:
-            logger.warning(
-                f"400: Bad request. Invalid subscription type: {event_sub.subscription.type}"
-            )
-            await notify(f"400: Bad request on {endpoint}. Invalid subscription type.")
-            raise HTTPException(status_code=400)
-
         fire_and_forget(task_func(event_sub), name=endpoint)
         return Response(status_code=202)
     except HTTPException:
         raise
+    except ValidationError as e:
+        # 4xx rather than 5xx deliberately: Twitch retries a 5xx, and a payload
+        # this model rejects will be rejected identically every time, so the
+        # retries only cost deliveries against the subscription's failure budget.
+        logger.warning(
+            f"400: {event_model.__name__} rejected the payload on {endpoint}"
+        )
+        await notify(
+            f"400: Bad request on {endpoint}."
+            f" Payload did not match {event_model.__name__}."
+        )
+        raise HTTPException(status_code=400) from e
     except Exception as e:
         await report(e, f"500: Internal server error on {endpoint}")
         raise HTTPException(status_code=500) from e
@@ -471,7 +505,6 @@ async def stream_online_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch",
         StreamOnlineEventSub,
-        "stream.online",
         _stream_online_task,
     )
 
@@ -482,7 +515,6 @@ async def stream_offline_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/offline",
         StreamOfflineEventSub,
-        "stream.offline",
         _stream_offline_task,
     )
 
@@ -493,7 +525,6 @@ async def channel_chat_message_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/chat",
         ChannelChatMessageEventSub,
-        "channel.chat.message",
         _channel_chat_message_task,
     )
 
@@ -504,7 +535,6 @@ async def channel_follow_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/follow",
         ChannelFollowEventSub,
-        "channel.follow",
         _channel_follow_task,
     )
 
@@ -515,7 +545,6 @@ async def channel_ad_break_begin_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/adbreak",
         ChannelAdBreakBeginEventSub,
-        "channel.ad_break.begin",
         _channel_ad_break_begin_task,
     )
 
@@ -548,7 +577,6 @@ async def channel_raid_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/raid",
         ChannelRaidEventSub,
-        "channel.raid",
         _channel_raid_task,
     )
 
@@ -570,6 +598,5 @@ async def channel_moderate_webhook(request: Request) -> Response:
         request,
         "/webhook/twitch/moderate",
         ChannelModerateEventSub,
-        "channel.moderate",
         _channel_moderate_task,
     )

--- a/controller/twitch_oauth.py
+++ b/controller/twitch_oauth.py
@@ -1,0 +1,206 @@
+"""The two Twitch authorization-code flows, on their own router.
+
+Separate from the webhook controller because it shares nothing with it: no
+signature checking, no EventSub models, a different path prefix.
+"""
+
+import logging
+
+from discord.utils import escape_markdown
+from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import RedirectResponse
+
+from config import settings
+from constants import TokenType
+from errors import notify, report
+from models import RefreshResponse, TokenValidationResponse
+from services.helper.http_client import http_client_manager
+from services.twitch.oauth import (
+    authorization_url,
+    callback_uri,
+    configured_scopes,
+    consume_authorization,
+    expected_user_id,
+)
+from services.twitch.token_manager import token_manager
+
+logger = logging.getLogger(__name__)
+
+twitch_oauth_router = APIRouter()
+
+# Twitch's denial text is short; anything longer is not from Twitch.
+_MAX_DENIAL_REASON = 200
+
+
+async def _validate_oauth_identity(
+    auth_response: RefreshResponse,
+    token_type: TokenType,
+    endpoint: str,
+) -> TokenValidationResponse:
+    response = await http_client_manager.request(
+        "GET",
+        "https://id.twitch.tv/oauth2/validate",
+        headers={"Authorization": f"OAuth {auth_response.access_token}"},
+    )
+    if response.status_code < 200 or response.status_code >= 300:
+        logger.error(
+            "OAuth token validation failed with status=%s", response.status_code
+        )
+        await notify(
+            f"Failed to validate the Twitch token from {endpoint}: "
+            f"{response.status_code} {response.text}"
+        )
+        raise HTTPException(status_code=500, detail="Twitch token validation failed")
+
+    validation = TokenValidationResponse.model_validate(response.json())
+    expected_id = expected_user_id(token_type)
+    missing_scopes = sorted(set(configured_scopes()) - set(validation.scopes))
+
+    problems = []
+    if validation.client_id != settings.twitch_client_id:
+        problems.append("the token belongs to a different Twitch application")
+    if validation.user_id != expected_id:
+        problems.append(
+            f"expected Twitch user ID {expected_id}, but {validation.login} "
+            f"authorized as ID {validation.user_id}"
+        )
+    if missing_scopes:
+        problems.append(f"missing scopes: {', '.join(missing_scopes)}")
+
+    if problems:
+        message = f"Rejected {token_type.value} authorization: {'; '.join(problems)}"
+        logger.warning(message)
+        await notify(message)
+        raise HTTPException(status_code=400, detail=message)
+    return validation
+
+
+async def _oauth_callback_common(
+    code: str | None,
+    state: str,
+    endpoint: str,
+    token_type: TokenType,
+    error: str | None,
+    error_description: str | None,
+) -> tuple[RefreshResponse, TokenValidationResponse]:
+    if not consume_authorization(token_type, state):
+        logger.warning("400: Bad request on %s. Invalid OAuth state.", endpoint)
+        await notify(f"400: Bad request on {endpoint}. Invalid or expired OAuth state.")
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+
+    if error:
+        # Both arrive in the callback query string, so neither is Twitch's word
+        # for anything. The caller is told only that it was denied; the reason
+        # goes to the admin channel, which is where it is actually read, capped
+        # and with mentions stripped on the way. !r for the log, where a bare
+        # newline would forge a line instead.
+        reason = (error_description or error)[:_MAX_DENIAL_REASON]
+        logger.warning("Twitch authorization denied on %s: %r", endpoint, reason)
+        await notify(
+            f"Twitch authorization denied on {endpoint}: {escape_markdown(reason)}",
+            key=f"oauth-denied:{endpoint}",
+        )
+        raise HTTPException(status_code=400, detail="Twitch authorization denied")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing Twitch authorization code")
+
+    params = {
+        "client_id": settings.twitch_client_id,
+        "client_secret": settings.twitch_client_secret,
+        "code": code,
+        "grant_type": "authorization_code",
+        "redirect_uri": callback_uri(token_type),
+    }
+    response = await http_client_manager.request(
+        "POST", "https://id.twitch.tv/oauth2/token", data=params
+    )
+
+    if response.status_code < 200 or response.status_code >= 300:
+        logger.error(
+            f"Token exchange failed with status={response.status_code}, response={response.text}"
+        )
+        await notify(
+            f"Failed to exchange token: {response.status_code} {response.text}"
+        )
+        raise HTTPException(status_code=500)
+
+    auth_response = RefreshResponse.model_validate(response.json())
+    if auth_response.token_type != "bearer":
+        logger.error(
+            f"Token exchange failed: unexpected token type {auth_response.token_type}"
+        )
+        await notify(
+            f"Failed to exchange token: unexpected token type {auth_response.token_type}"
+        )
+        raise HTTPException(status_code=500)
+    validation = await _validate_oauth_identity(auth_response, token_type, endpoint)
+    return auth_response, validation
+
+
+@twitch_oauth_router.get("/twitch/oauth/start/{identity}")
+async def twitch_oauth_start(identity: str, state: str) -> Response:
+    try:
+        token_type = TokenType(identity)
+        return RedirectResponse(authorization_url(token_type, state), status_code=302)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None
+
+
+@twitch_oauth_router.get("/twitch/oauth/callback")
+async def twitch_oauth_callback(
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+) -> Response:
+    try:
+        auth_response, validation = await _oauth_callback_common(
+            code,
+            state,
+            "/twitch/oauth/callback",
+            TokenType.User,
+            error,
+            error_description,
+        )
+        await token_manager.set_user_access_token(auth_response)
+        return Response(
+            f"Authorization successful for bot account {validation.login} "
+            f"({validation.user_id}). You can close this tab.",
+            status_code=200,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        await report(e, "500: Internal server error on /twitch/oauth/callback")
+        raise HTTPException(status_code=500) from e
+
+
+@twitch_oauth_router.get("/twitch/oauth/callback/broadcaster")
+async def twitch_oauth_callback_broadcaster(
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+) -> Response:
+    try:
+        auth_response, validation = await _oauth_callback_common(
+            code,
+            state,
+            "/twitch/oauth/callback/broadcaster",
+            TokenType.Broadcaster,
+            error,
+            error_description,
+        )
+        await token_manager.set_broadcaster_access_token(auth_response)
+        return Response(
+            f"Authorization successful for broadcaster account {validation.login} "
+            f"({validation.user_id}). You can close this tab.",
+            status_code=200,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        await report(
+            e, "500: Internal server error on /twitch/oauth/callback/broadcaster"
+        )
+        raise HTTPException(status_code=500) from e

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ truststore.inject_into_ssl()
 import asyncio
 import logging
 import os
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Response
@@ -15,7 +16,7 @@ from rich.logging import RichHandler
 from background import fire_and_forget
 from config import settings
 from constants import COGS
-from controller import twitch_router
+from controller import twitch_oauth_router, twitch_router
 from errors import report
 from init import bot
 from services.helper.http_client import http_client_manager
@@ -57,7 +58,7 @@ async def main() -> None:
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     fire_and_forget(main(), name="bot")
     yield
     await http_client_manager.close()
@@ -65,6 +66,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(twitch_router)
+app.include_router(twitch_oauth_router)
 
 
 def static_file_response(filename: str) -> Response:

--- a/models/twitch_event_subs/channel_ad_break_begin.py
+++ b/models/twitch_event_subs/channel_ad_break_begin.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from .common import Subscription
@@ -8,6 +10,7 @@ class ChannelAdBreakBeginCondition(BaseModel):
 
 
 class ChannelAdBreakBeginSubscription(Subscription):
+    type: Literal["channel.ad_break.begin"]
     condition: ChannelAdBreakBeginCondition
 
 

--- a/models/twitch_event_subs/channel_chat_message.py
+++ b/models/twitch_event_subs/channel_chat_message.py
@@ -49,16 +49,16 @@ class ChannelChatMessageEvent(BaseModel):
         "power_ups_gigantified_emote",
     ]
     badges: list[Badge]
-    cheer: Cheer | None
-    color: str | None
-    reply: Reply | None
-    channel_points_custom_reward_id: str | None
-    source_broadcaster_user_id: str | None
-    source_broadcaster_user_name: str | None
-    source_broadcaster_user_login: str | None
-    source_message_id: str | None
-    source_badges: list[Badge] | None
-    is_source_only: bool | None
+    cheer: Cheer | None = None
+    color: str | None = None
+    reply: Reply | None = None
+    channel_points_custom_reward_id: str | None = None
+    source_broadcaster_user_id: str | None = None
+    source_broadcaster_user_name: str | None = None
+    source_broadcaster_user_login: str | None = None
+    source_message_id: str | None = None
+    source_badges: list[Badge] | None = None
+    is_source_only: bool | None = None
 
 
 class ChannelChatMessageEventSub(BaseModel):

--- a/models/twitch_event_subs/channel_chat_message.py
+++ b/models/twitch_event_subs/channel_chat_message.py
@@ -11,6 +11,7 @@ class ChannelChatMessageCondition(BaseModel):
 
 
 class ChannelChatMessageSubscription(Subscription):
+    type: Literal["channel.chat.message"]
     condition: ChannelChatMessageCondition
 
 

--- a/models/twitch_event_subs/channel_chat_notification.py
+++ b/models/twitch_event_subs/channel_chat_notification.py
@@ -11,6 +11,7 @@ class ChannelChatNotificationCondition(BaseModel):
 
 
 class ChannelChatNotificationSubscription(Subscription):
+    type: Literal["channel.chat.notification"]
     condition: ChannelChatNotificationCondition
 
 

--- a/models/twitch_event_subs/channel_chat_notification.py
+++ b/models/twitch_event_subs/channel_chat_notification.py
@@ -1,6 +1,10 @@
-from typing import Literal
+"""Modelled ahead of its route: nothing subscribes to channel.chat.notification
+yet and no endpoint serves it. Deliberate, not an oversight.
+"""
 
-from pydantic import BaseModel
+from typing import Literal, Self
+
+from pydantic import BaseModel, model_validator
 
 from .common import Badge, Message, Subscription
 
@@ -152,6 +156,17 @@ class ChannelChatNotificationEvent(BaseModel):
     shared_chat_pay_it_forward: PayItForward | None
     shared_chat_raid: Raid | None
     shared_chat_announcement: Announcement | None
+
+    @model_validator(mode="after")
+    def _detail_for_notice(self) -> Self:
+        """Twitch fills the field its notice_type names, so a payload without it is
+        one this model has read wrongly. Others may be set too; that is not an error.
+        """
+        # Default, not a bare lookup: a notice type added to the Literal without
+        # its field should fail as a validation error, not an AttributeError.
+        if getattr(self, self.notice_type, None) is None:
+            raise ValueError(f"notice_type {self.notice_type!r} carries no detail")
+        return self
 
 
 class ChannelChatNotificationEventSub(BaseModel):

--- a/models/twitch_event_subs/channel_chat_notification.py
+++ b/models/twitch_event_subs/channel_chat_notification.py
@@ -21,7 +21,7 @@ class ChannelChatNotificationSubscription(Subscription):
 
 class Sub(BaseModel):
     sub_tier: Literal["1000", "2000", "3000"]
-    is_prime: bool | None
+    is_prime: bool | None = None
     duration_months: int
 
 
@@ -29,31 +29,31 @@ class Resub(Sub):
     cumulative_months: int
     streak_months: int
     is_gift: bool
-    gifter_is_anonymous: bool | None
-    gifter_user_id: str | None
-    gifter_user_name: str | None
-    gifter_user_login: str | None
+    gifter_is_anonymous: bool | None = None
+    gifter_user_id: str | None = None
+    gifter_user_name: str | None = None
+    gifter_user_login: str | None = None
 
 
 class SubGift(Sub):
-    cumulative_total: int | None
+    cumulative_total: int | None = None
     recipient_user_id: str
     recipient_user_name: str
     recipient_user_login: str
-    community_gift_id: str | None
+    community_gift_id: str | None = None
 
 
 class CommunitySubGift(BaseModel):
     id: str
     total: int
     sub_tier: Literal["1000", "2000", "3000"]
-    cumulative_total: int | None
+    cumulative_total: int | None = None
 
 
 class GiftPaidUpgrade(BaseModel):
     gifter_is_anonymous: bool
-    gifter_user_id: str | None
-    gifter_user_name: str | None
+    gifter_user_id: str | None = None
+    gifter_user_name: str | None = None
 
 
 class PrimePaidUpgrade(BaseModel):
@@ -61,7 +61,7 @@ class PrimePaidUpgrade(BaseModel):
 
 
 class PayItForward(GiftPaidUpgrade):
-    gifter_user_login: str | None
+    gifter_user_login: str | None = None
 
 
 class Raid(BaseModel):
@@ -93,6 +93,17 @@ class Amount(BaseModel):
 class CharityDonation(BaseModel):
     charity_name: str
     amount: Amount
+
+
+# Twitch documents unraid as "Returns an empty payload if notice_type is not
+# unraid, otherwise returns null" — the one type whose field is empty exactly when
+# it applies, inverting the rule the validator below asserts. The docs do not say
+# which way is real, so nothing is asserted for it either way.
+#
+# The Literal below also carries 21 of the 25 types Twitch documents. watch_streak,
+# modiversary and shared_chat_modiversary are unmodelled, and "unknown" names no
+# field at all, so completing the list needs entries here as well as fields.
+_NO_DETAIL = {"unraid"}
 
 
 class ChannelChatNotificationEvent(BaseModel):
@@ -130,38 +141,42 @@ class ChannelChatNotificationEvent(BaseModel):
         "shared_chat_pay_it_forward",
         "shared_chat_announcement",
     ]
-    sub: Sub | None
-    resub: Resub | None
-    sub_gift: SubGift | None
-    community_sub_gift: CommunitySubGift | None
-    gift_paid_upgrade: GiftPaidUpgrade | None
-    prime_paid_upgrade: PrimePaidUpgrade | None
-    pay_it_forward: PayItForward | None
-    raid: Raid | None
-    unraid: Unraid | None
-    announcement: Announcement | None
-    bits_badge_tier: BitsBadgeTier | None
-    charity_donation: CharityDonation | None
-    source_broadcaster_user_id: str | None
-    source_broadcaster_user_name: str | None
-    source_broadcaster_user_login: str | None
-    source_message_id: str | None
-    source_badges: list[Badge] | None
-    shared_chat_sub: Sub | None
-    shared_chat_resub: Resub | None
-    shared_chat_sub_gift: SubGift | None
-    shared_chat_community_sub_gift: CommunitySubGift | None
-    shared_chat_gift_paid_upgrade: GiftPaidUpgrade | None
-    shared_chat_prime_paid_upgrade: PrimePaidUpgrade | None
-    shared_chat_pay_it_forward: PayItForward | None
-    shared_chat_raid: Raid | None
-    shared_chat_announcement: Announcement | None
+    sub: Sub | None = None
+    resub: Resub | None = None
+    sub_gift: SubGift | None = None
+    community_sub_gift: CommunitySubGift | None = None
+    gift_paid_upgrade: GiftPaidUpgrade | None = None
+    prime_paid_upgrade: PrimePaidUpgrade | None = None
+    pay_it_forward: PayItForward | None = None
+    raid: Raid | None = None
+    unraid: Unraid | None = None
+    announcement: Announcement | None = None
+    bits_badge_tier: BitsBadgeTier | None = None
+    charity_donation: CharityDonation | None = None
+    source_broadcaster_user_id: str | None = None
+    source_broadcaster_user_name: str | None = None
+    source_broadcaster_user_login: str | None = None
+    source_message_id: str | None = None
+    source_badges: list[Badge] | None = None
+    shared_chat_sub: Sub | None = None
+    shared_chat_resub: Resub | None = None
+    shared_chat_sub_gift: SubGift | None = None
+    shared_chat_community_sub_gift: CommunitySubGift | None = None
+    shared_chat_gift_paid_upgrade: GiftPaidUpgrade | None = None
+    shared_chat_prime_paid_upgrade: PrimePaidUpgrade | None = None
+    shared_chat_pay_it_forward: PayItForward | None = None
+    shared_chat_raid: Raid | None = None
+    shared_chat_announcement: Announcement | None = None
 
     @model_validator(mode="after")
     def _detail_for_notice(self) -> Self:
-        """Twitch fills the field its notice_type names, so a payload without it is
-        one this model has read wrongly. Others may be set too; that is not an error.
+        """Twitch fills the field its notice_type names, where one is named.
+
+        Not every type names one, so this asserts nothing about those rather than
+        assuming a rule that does not hold for all of them.
         """
+        if self.notice_type in _NO_DETAIL:
+            return self
         # Default, not a bare lookup: a notice type added to the Literal without
         # its field should fail as a validation error, not an AttributeError.
         if getattr(self, self.notice_type, None) is None:

--- a/models/twitch_event_subs/channel_follow.py
+++ b/models/twitch_event_subs/channel_follow.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from .common import Subscription
@@ -9,6 +11,7 @@ class ChannelFollowCondition(BaseModel):
 
 
 class ChannelFollowSubscription(Subscription):
+    type: Literal["channel.follow"]
     condition: ChannelFollowCondition
 
 

--- a/models/twitch_event_subs/channel_moderate.py
+++ b/models/twitch_event_subs/channel_moderate.py
@@ -30,11 +30,11 @@ class User(BaseModel):
 
 
 class Ban(User):
-    reason: str | None
+    reason: str | None = None
 
 
 class Timeout(User):
-    reason: str | None
+    reason: str | None = None
     expires_at: str
 
 
@@ -56,21 +56,21 @@ class AutomodTerms(BaseModel):
 
 class UnbanRequest(User):
     is_approved: bool
-    moderator_message: str | None
+    moderator_message: str | None = None
 
 
 class Warn(User):
-    reason: str | None
-    chat_rules_cited: list[str] | None
+    reason: str | None = None
+    chat_rules_cited: list[str] | None = None
 
 
 class ChannelModerateEvent(BaseModel):
     broadcaster_user_id: str
     broadcaster_user_login: str
     broadcaster_user_name: str
-    source_broadcaster_user_id: str | None
-    source_broadcaster_user_login: str | None
-    source_broadcaster_user_name: str | None
+    source_broadcaster_user_id: str | None = None
+    source_broadcaster_user_login: str | None = None
+    source_broadcaster_user_name: str | None = None
     moderator_user_id: str
     moderator_user_login: str
     moderator_user_name: str
@@ -110,27 +110,27 @@ class ChannelModerateEvent(BaseModel):
         "shared_chat_untimeout",
         "shared_chat_delete",
     ]
-    followers: Followers | None
-    slow: Slow | None
-    vip: User | None
-    unvip: User | None
-    mod: User | None
-    unmod: User | None
-    ban: Ban | None
-    unban: User | None
-    timeout: Timeout | None
-    untimeout: User | None
-    raid: Raid | None
-    unraid: User | None
-    delete: Delete | None
-    automod_terms: AutomodTerms | None
-    unban_request: UnbanRequest | None
-    warn: Warn | None
-    shared_chat_ban: Ban | None
-    shared_chat_unban: User | None
-    shared_chat_timeout: Timeout | None
-    shared_chat_untimeout: User | None
-    shared_chat_delete: Delete | None
+    followers: Followers | None = None
+    slow: Slow | None = None
+    vip: User | None = None
+    unvip: User | None = None
+    mod: User | None = None
+    unmod: User | None = None
+    ban: Ban | None = None
+    unban: User | None = None
+    timeout: Timeout | None = None
+    untimeout: User | None = None
+    raid: Raid | None = None
+    unraid: User | None = None
+    delete: Delete | None = None
+    automod_terms: AutomodTerms | None = None
+    unban_request: UnbanRequest | None = None
+    warn: Warn | None = None
+    shared_chat_ban: Ban | None = None
+    shared_chat_unban: User | None = None
+    shared_chat_timeout: Timeout | None = None
+    shared_chat_untimeout: User | None = None
+    shared_chat_delete: Delete | None = None
 
 
 class ChannelModerateEventSub(BaseModel):

--- a/models/twitch_event_subs/channel_moderate.py
+++ b/models/twitch_event_subs/channel_moderate.py
@@ -11,6 +11,7 @@ class ChannelModerateCondition(BaseModel):
 
 
 class ChannelModerateSubscription(Subscription):
+    type: Literal["channel.moderate"]
     condition: ChannelModerateCondition
 
 

--- a/models/twitch_event_subs/channel_raid.py
+++ b/models/twitch_event_subs/channel_raid.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from .common import Subscription
@@ -9,6 +11,7 @@ class ChannelRaidCondition(BaseModel):
 
 
 class ChannelRaidSubscription(Subscription):
+    type: Literal["channel.raid"]
     condition: ChannelRaidCondition
 
 

--- a/models/twitch_event_subs/common/message.py
+++ b/models/twitch_event_subs/common/message.py
@@ -25,9 +25,9 @@ class Mention(BaseModel):
 class Fragment(BaseModel):
     type: Literal["text", "cheermote", "emote", "mention"]
     text: str
-    cheermote: Cheermote | None
-    emote: Emote | None
-    mention: Mention | None
+    cheermote: Cheermote | None = None
+    emote: Emote | None = None
+    mention: Mention | None = None
 
 
 class Message(BaseModel):

--- a/models/twitch_event_subs/common/subscription.py
+++ b/models/twitch_event_subs/common/subscription.py
@@ -2,10 +2,11 @@ from pydantic import BaseModel
 
 
 class Subscription(BaseModel):
-    """Everything an EventSub subscription carries except its type.
+    """The fields every EventSub subscription carries that mean the same thing.
 
-    Each subclass declares that as a Literal, so a payload for the wrong event
-    fails to parse. A str here could not be narrowed to one soundly.
+    Not type, which each subclass declares as a Literal so a payload for the
+    wrong event fails to parse; a str here could not be narrowed to one soundly.
+    Not transport either, which is in the payload but nothing here reads.
     """
 
     id: str

--- a/models/twitch_event_subs/common/subscription.py
+++ b/models/twitch_event_subs/common/subscription.py
@@ -2,8 +2,13 @@ from pydantic import BaseModel
 
 
 class Subscription(BaseModel):
+    """Everything an EventSub subscription carries except its type.
+
+    Each subclass declares that as a Literal, so a payload for the wrong event
+    fails to parse. A str here could not be narrowed to one soundly.
+    """
+
     id: str
-    type: str
     version: str
     status: str
     cost: int

--- a/models/twitch_event_subs/stream_offline.py
+++ b/models/twitch_event_subs/stream_offline.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from .common import Subscription
@@ -8,6 +10,7 @@ class StreamOfflineCondition(BaseModel):
 
 
 class StreamOfflineSubscription(Subscription):
+    type: Literal["stream.offline"]
     condition: StreamOfflineCondition
 
 

--- a/models/twitch_event_subs/stream_online.py
+++ b/models/twitch_event_subs/stream_online.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from .common import Subscription
@@ -8,6 +10,7 @@ class StreamOnlineCondition(BaseModel):
 
 
 class StreamOnlineSubscription(Subscription):
+    type: Literal["stream.online"]
     condition: StreamOnlineCondition
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ typeCheckingMode = "standard"
 # No exclude key: setting it REPLACES pyright's defaults instead of adding to
 # them, and those already cover .venv and __pycache__. "M.m" only, and required.
 pythonVersion = "3.14"
+# The webhook dispatcher is generic in its model, which binds a route to its
+# handler only as strongly as the handler annotates its own parameter. Without
+# this an unannotated handler is Any and pairs with anything.
+reportMissingParameterType = "error"
 venvPath = "."
 venv = ".venv"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Valin Malach's bot for Twitch/Discord"
 readme = "README.md"
 requires-python = ">=3.14.7"
 dependencies = [
-    "alembic>=1.19.1",
+    "alembic>=1.19.2",
     "asyncpg>=0.31.0",
     "discord>=2.3.2",
     "fastapi>=0.141.1",

--- a/services/helper/http_client.py
+++ b/services/helper/http_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from typing import Self, cast
+from types import TracebackType
+from typing import Any, Self, cast
 
 import httpx
 
@@ -59,10 +60,15 @@ class HttpClientManager:
                     self._client = None
                     logger.info("Global HTTP client closed")
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> httpx.AsyncClient:
         return await self.get_client()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         # Don't close on context exit to maintain global connection pool
         pass
 
@@ -75,7 +81,7 @@ class HttpClientManager:
         params: dict | None = None,
         json: dict | None = None,
         data: dict | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> httpx.Response:
         """Make an HTTP request using the global client.
 

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -1,0 +1,202 @@
+"""What each EventSub notification makes the bot do.
+
+Lives here rather than beside the routes because none of it touches HTTP: it
+orchestrates the alert, the session, chat and Helix, and only happens to be
+triggered by a webhook.
+"""
+
+import asyncio
+import logging
+import time
+
+from errors import notify, report
+from models import (
+    ChannelAdBreakBeginEventSub,
+    ChannelChatMessageEventSub,
+    ChannelFollowEventSub,
+    ChannelModerateEventSub,
+    ChannelRaidEventSub,
+    Stream,
+    StreamOfflineEventSub,
+    StreamOnlineEventSub,
+)
+from services import get_stream, get_user
+from services.config import config
+from services.twitch import live_alert, stream_session
+from services.twitch.chat import say, say_template
+from services.twitch.commands import dispatch
+from services.twitch.helix import HelixError
+
+logger = logging.getLogger(__name__)
+
+# Twitch announces the stream before Helix lists it. Bounded by the clock rather
+# than by a count of attempts: a lookup that is timing out takes most of a minute
+# on its own, so thirty of those is a quarter of an hour, not thirty seconds.
+_STREAM_WAIT_SECONDS = 60
+
+
+async def _wait_for_stream_info(
+    broadcaster_id: int,
+) -> tuple[Stream | None, HelixError | None]:
+    """Poll until Twitch admits the stream is up, tolerating a failed lookup.
+
+    Bounded, because Twitch delivers stream.online once and never again: waiting
+    forever and giving up both lose the alert, but only one of them says so. The
+    last lookup error comes back too, so giving up can tell "Twitch says they
+    are offline" from "Twitch could not be reached".
+    """
+    deadline = time.monotonic() + _STREAM_WAIT_SECONDS
+    last_error: HelixError | None = None
+
+    while True:
+        try:
+            stream_info = await get_stream(broadcaster_id)
+        except HelixError as e:
+            last_error = e
+            logger.warning(f"Stream lookup failed for {broadcaster_id}: {e}")
+            stream_info = None
+
+        if stream_info:
+            return stream_info, None
+        # Checked after the attempt, so a slow first lookup still gets its turn.
+        if time.monotonic() >= deadline:
+            return None, last_error
+        await asyncio.sleep(1)
+
+
+async def stream_online(event_sub: StreamOnlineEventSub) -> None:
+    broadcaster_id = int(event_sub.event.broadcaster_user_id)
+    try:
+        stream_info, lookup_error = await _wait_for_stream_info(broadcaster_id)
+        if stream_info is None:
+            reason = (
+                f"the last lookup failed: {lookup_error}"
+                if lookup_error is not None
+                else "Twitch went on reporting them offline"
+            )
+            await notify(
+                f"Gave up after {_STREAM_WAIT_SECONDS}s waiting for Twitch to confirm"
+                f" broadcaster {broadcaster_id} is live, so no alert was posted and no"
+                f" stream session was started: {reason}",
+                key=f"stream-online-gave-up:{broadcaster_id}",
+            )
+            return
+
+        try:
+            user_info = await get_user(broadcaster_id)
+        except HelixError as e:
+            # Decoration. stream.online does not come again, so the alert must
+            # not depend on it.
+            await notify(
+                f"Announcing broadcaster {broadcaster_id} without their profile: {e}",
+                key=f"stream-online-profile:{broadcaster_id}",
+            )
+            user_info = None
+
+        is_main = stream_info.user_login == config.setting("broadcaster_username")
+        channel = (
+            config.channel("stream_alerts") if is_main else config.channel("promo")
+        )
+
+        # began does not raise: it guards each of its own chat lines, because
+        # the alert below must survive a Twitch that will not take a greeting.
+        await stream_session.began(broadcaster_id, stream_info)
+
+        await live_alert.announce(broadcaster_id, stream_info, user_info, channel)
+
+    except Exception as e:  # noqa: BLE001
+        await report(e, f"Error in _stream_online_task for {broadcaster_id}")
+
+
+async def stream_offline(event_sub: StreamOfflineEventSub) -> None:
+    broadcaster_id = int(event_sub.event.broadcaster_user_id)
+    try:
+        # The payload names no stream, so this handler cannot tell which one
+        # ended. It wakes the updater, which can. See docs/adr/0001.
+        await live_alert.wake(broadcaster_id)
+
+    except Exception as e:  # noqa: BLE001
+        await report(e, f"Error in _stream_offline_task for {broadcaster_id}")
+
+
+async def channel_chat_message(event_sub: ChannelChatMessageEventSub) -> None:
+    try:
+        if not event_sub.event.message.text.startswith("!"):
+            return
+        text_without_prefix = event_sub.event.message.text[1:]
+        command_parts = text_without_prefix.split(" ", 1)
+        command = command_parts[0].lower()
+        args = command_parts[1] if len(command_parts) > 1 else ""
+
+        if (
+            event_sub.event.source_broadcaster_user_id is not None
+            and event_sub.event.source_broadcaster_user_id
+            != event_sub.event.broadcaster_user_id
+        ):
+            return
+
+        await dispatch(event_sub, command, args)
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch chat webhook task")
+
+
+async def channel_follow(event_sub: ChannelFollowEventSub) -> None:
+    try:
+        await say_template(
+            event_sub.event.broadcaster_user_id,
+            "twitch_follow_thanks",
+            user=event_sub.event.user_name,
+        )
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch follow webhook task")
+
+
+async def channel_ad_break_begin(event_sub: ChannelAdBreakBeginEventSub) -> None:
+    broadcaster_id = event_sub.event.broadcaster_user_id
+    try:
+        ad_duration = event_sub.event.duration_seconds
+
+        # Each step stands alone: a dropped "ads starting" used to take the
+        # "ads over" message and the next break's warning down with it.
+        await say_template(
+            broadcaster_id, "twitch_ad_break_start", minutes=ad_duration // 60
+        )
+        await asyncio.sleep(ad_duration)
+        await say_template(broadcaster_id, "twitch_ad_break_end")
+
+        stream_session.schedule_ad_break_warning(broadcaster_id)
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch ad break webhook task")
+
+
+async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
+    try:
+        if stream_session.is_main_broadcaster(event_sub.event.from_broadcaster_user_id):
+            twitch_url = (
+                f"https://www.twitch.tv/{event_sub.event.to_broadcaster_user_login}"
+            )
+            await say_template(
+                event_sub.event.from_broadcaster_user_id,
+                "twitch_raid_out",
+                name=event_sub.event.to_broadcaster_user_name,
+                url=twitch_url,
+            )
+        elif stream_session.is_main_broadcaster(event_sub.event.to_broadcaster_user_id):
+            await say(
+                event_sub.event.to_broadcaster_user_id,
+                f"!so {event_sub.event.from_broadcaster_user_login}",
+                "the incoming raid shoutout",
+            )
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch raid webhook task")
+
+
+async def channel_moderate(event_sub: ChannelModerateEventSub) -> None:
+    try:
+        if event_sub.event.action != "raid" or not stream_session.is_main_broadcaster(
+            event_sub.event.broadcaster_user_id
+        ):
+            return
+        await say_template(event_sub.event.broadcaster_user_id, "twitch_raid_farewell")
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch moderate webhook task")

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -20,9 +20,9 @@ from models import (
     StreamOfflineEventSub,
     StreamOnlineEventSub,
 )
-from services import get_stream, get_user
 from services.config import config
 from services.twitch import live_alert, stream_session
+from services.twitch.api import get_stream, get_user
 from services.twitch.chat import say, say_template
 from services.twitch.commands import dispatch
 from services.twitch.helix import HelixError
@@ -105,7 +105,7 @@ async def stream_online(event_sub: StreamOnlineEventSub) -> None:
         await live_alert.announce(broadcaster_id, stream_info, user_info, channel)
 
     except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in _stream_online_task for {broadcaster_id}")
+        await report(e, f"Error in stream_online for {broadcaster_id}")
 
 
 async def stream_offline(event_sub: StreamOfflineEventSub) -> None:
@@ -116,7 +116,7 @@ async def stream_offline(event_sub: StreamOfflineEventSub) -> None:
         await live_alert.wake(broadcaster_id)
 
     except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in _stream_offline_task for {broadcaster_id}")
+        await report(e, f"Error in stream_offline for {broadcaster_id}")
 
 
 async def channel_chat_message(event_sub: ChannelChatMessageEventSub) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -83,16 +83,16 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.19.1"
+version = "1.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/2b/e4153978368de59918115c9e01d3ebf58a558a7285efa7e960c383c4b59a/alembic-1.19.1.tar.gz", hash = "sha256:e0fca0518118c78acc493e31bcb5402f190057aaf6df8b5b95ce94c4789cf648", size = 2070816, upload-time = "2026-08-08T16:32:01.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl", hash = "sha256:b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be", size = 265946, upload-time = "2026-08-08T16:32:03.153Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
 ]
 
 [[package]]
@@ -115,14 +115,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
 ]
 
 [[package]]
@@ -913,7 +914,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = ">=1.19.1" },
+    { name = "alembic", specifier = ">=1.19.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "discord", specifier = ">=2.3.2" },
     { name = "fastapi", specifier = ">=0.141.1" },


### PR DESCRIPTION
## Summary by Sourcery

Split Twitch webhook, event-processing, and OAuth responsibilities into focused modules while hardening EventSub validation, freshness, and duplicate-delivery handling.

New Features:
- Add replay protection and timestamp freshness validation for Twitch EventSub notifications.
- Expose Twitch OAuth flows through a dedicated router.
- Strengthen EventSub payload validation with event-specific subscription types and notification detail checks.

Bug Fixes:
- Return clear client errors for malformed or mismatched signed webhook payloads instead of treating them as server failures.
- Allow optional Twitch payload fields to be omitted without validation failures.

Enhancements:
- Separate Twitch webhook transport, OAuth endpoints, and event handling into dedicated modules while preserving existing bot behavior.
- Tie webhook models to their handlers with stronger static typing and dispatch duplicate deliveries safely.

Build:
- Update the uv and Alembic dependency versions and pin the localtunnel container image by digest.
- Enable stricter Pyright parameter type checking.

Deployment:
- Pin the localtunnel image used in the container build to a known digest.

Documentation:
- Document the separated Twitch controller responsibilities, webhook validation behavior, replay protection, and subscription limitations.

Chores:
- Add precise type annotations to the shared HTTP client lifecycle and request helpers.