### PR TITLE
fix: Roll a birthday forward in the zone it was set in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,14 +251,20 @@ means Twitch has nothing, a failed call raises. Retry follows the method, not th
 call site; `docs/adr/0002-helix-posts-are-not-retried.md` says why POSTs do not.
 
 **A stored birthday is the next occurrence, not a date of birth.** One rule
-answers when that is: `next_birthday_on` when it is being set, `next_birthday`
-when it is being rolled forward, both in `services/birthday.py`. Two
-implementations of it disagreed once and `/birthday set` wrote dates that had
-already passed. `is_leap_day` is there for the same reason and is derived nowhere
-else — its answer picks the year the instant lands in *and* is stored beside it
-as `is_birthday_leap`, so a second copy could put those two out of step.
+answers when that is: `next_birthday_on` from the parts when it is being set,
+`next_birthday` from the instant when it is being rolled forward, both in
+`services/birthday.py`. Two implementations of it disagreed once and
+`/birthday set` wrote dates that had already passed, which is why the second now
+asks the first: it reads the local date back off the instant using
+`birthday_timezone` and hands it over as parts. Only a row written before that
+column existed has no zone to read, and falls back to bumping the year on the
+instant. `is_leap_day` is derived nowhere else — its answer picks the year the
+instant lands in *and* is stored beside it as `is_birthday_leap`, so a second
+copy could put those two out of step; the timezone path leaves it to
+`next_birthday_on`, which asks the same predicate. All three birthday columns
+are written together by `upsert_user`, since they describe one birthday.
 `docs/adr/0003-birthday-holds-the-next-occurrence.md` records why the column
-holds an instant, and what discarding the timezone costs — issue #12.
+holds an instant.
 
 **Two model packages with confusable names.** `models/` is Pydantic: Twitch API
 responses and EventSub payloads. `db/models/` is SQLModel: the tables.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,10 @@ answers when that is: `next_birthday_on` from the parts when it is being set,
 asks the first: it reads the local date back off the instant using
 `birthday_timezone` and hands it over as parts. Only a row written before that
 column existed has no zone to read, and falls back to bumping the year on the
-instant. `is_leap_day` is derived nowhere else — its answer picks the year the
+instant, and a name the tz database has dropped since is cleared with a notice
+rather than raised: `next_birthday` is called one line *before* the write that
+reschedules the record, so anything that raises there is a birthday that never
+moves and so is never greeted again. `is_leap_day` is derived nowhere else — its answer picks the year the
 instant lands in *and* is stored beside it as `is_birthday_leap`, so a second
 copy could put those two out of step; the timezone path leaves it to
 `next_birthday_on`, which asks the same predicate. All three birthday columns

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,15 +99,18 @@ _Avoid_: shoutout list, so queue
 ### Birthdays
 
 **Stored birthday**:
-The next occurrence of someone's birthday, held as an instant in UTC. Never a
-date of birth: the year is chosen rather than remembered, and it moves.
+The next occurrence of someone's birthday, held as an instant in UTC beside the
+timezone it was set in. Never a date of birth: the year is chosen rather than
+remembered, and it moves.
 _Avoid_: birth date, DOB, birthday date
 
 **Roll forward**:
 Moving a **stored birthday** to its next occurrence. The same question asked
-when a birthday is set and when one has just been greeted — but not yet the same
-answer: setting one knows the timezone and rolling one forward has had it
-discarded, so the two disagree wherever a zone's rules move the local day.
+when a birthday is set and when one has just been greeted, and now the same
+answer: rolling forward reads the local date back out of the instant and asks
+the setting rule for the parts. A row stored before the timezone was kept has
+none to read, and falls back to bumping the year on the instant — which is what
+moved the local day in 201 of 598 zones.
 _Avoid_: reschedule, bump, advance
 
 **Stale birthday**:

--- a/cogs/birthday.py
+++ b/cogs/birthday.py
@@ -47,6 +47,7 @@ class Birthday(GroupCog):
                 interaction.user.name,
                 next_birthday_on(month, day, timezone, pendulum.now("UTC")),
                 is_leap,
+                timezone,
             )
 
             await interaction.response.send_message(
@@ -114,9 +115,9 @@ class Birthday(GroupCog):
                 return
 
             had_birthday = existing_user.birthday is not None
-            # The explicit Nones are the removal: they clear both columns.
+            # The explicit Nones are the removal: they clear all three columns.
             await repository.upsert_user(
-                interaction.user.id, interaction.user.name, None, None
+                interaction.user.id, interaction.user.name, None, None, None
             )
 
             if had_birthday:

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -115,7 +115,7 @@ class Tasks(Cog):
         # is a greeting nobody sent, but if the write failed after a greeting
         # went out it is the same greeting again, every quarter of an hour.
         leap = bool(record.is_birthday_leap)
-        zone = record.birthday_timezone
+        zone = await self._usable_timezone(record)
         next_at = next_birthday(record.birthday, leap, now, zone)
         await repository.upsert_user(record.id, record.username, next_at, leap, zone)
 
@@ -129,6 +129,31 @@ class Tasks(Cog):
             return
 
         await self._announce_birthday(record)
+
+    @staticmethod
+    async def _usable_timezone(record: DiscordUser) -> str | None:
+        """The record's timezone, or None if it is not one any more.
+
+        next_birthday raises on a name pendulum cannot resolve, and it is called
+        before the write above deliberately - so a raise there is a birthday
+        that never moves, comes due on every tick and is never greeted again.
+        The tz database does drop names: US/Pacific-New went in 2020. Clearing
+        the column degrades that row to the UTC roll, which is wrong by a day at
+        worst rather than silent, and stops the notice repeating for ever.
+        """
+        zone = record.birthday_timezone
+        if zone is None or zone in pendulum.timezones():
+            return zone
+
+        await notify(
+            f"Birthday timezone {escape_markdown(zone)} for"
+            f" {escape_markdown(record.username)} (ID: {record.id}) is not a timezone"
+            " any more, so it has been cleared and their birthday now rolls forward"
+            " in UTC, which can land on the wrong local day. Re-running"
+            " /birthday set fixes it.",
+            key=f"birthday-bad-zone:{record.id}",
+        )
+        return None
 
     @staticmethod
     def _within_announce_grace(birthday: datetime, now: pendulum.DateTime) -> bool:

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -115,8 +115,9 @@ class Tasks(Cog):
         # is a greeting nobody sent, but if the write failed after a greeting
         # went out it is the same greeting again, every quarter of an hour.
         leap = bool(record.is_birthday_leap)
-        next_at = next_birthday(record.birthday, leap, now)
-        await repository.upsert_user(record.id, record.username, next_at, leap)
+        zone = record.birthday_timezone
+        next_at = next_birthday(record.birthday, leap, now, zone)
+        await repository.upsert_user(record.id, record.username, next_at, leap, zone)
 
         if stale:
             await notify(

--- a/db/README.md
+++ b/db/README.md
@@ -69,7 +69,7 @@ uvx pyright                                        # same settings Pylance uses
 
 | Table | Replaces | Notes |
 | --- | --- | --- |
-| `discord_user` | `data/users.parquet` | `isBirthdayLeap` → `is_birthday_leap`; `birthday` becomes a real `timestamptz` holding the next occurrence in UTC |
+| `discord_user` | `data/users.parquet` | `isBirthdayLeap` → `is_birthday_leap`; `birthday` becomes a real `timestamptz` holding the next occurrence in UTC, with `birthday_timezone` beside it so rolling it forward can rebuild the local date |
 | `discord_message` | `data/messages.parquet` | `attachment_urls` becomes a `JSONB` array instead of a JSON string |
 | `live_alert` | `data/live_alerts.parquet` | the parquet `id` is the Twitch broadcaster, so it is named `broadcaster_id` |
 

--- a/db/models/records.py
+++ b/db/models/records.py
@@ -18,6 +18,8 @@ class DiscordUser(TimestampMixin, table=True):
     """A guild member and, optionally, their next birthday.
 
     ``birthday`` holds the next occurrence in UTC, which the birthday task matches on.
+    ``birthday_timezone`` is what the roll-forward rebuilds the local date in; it
+    is null on every row written before the column existed.
     """
 
     __tablename__ = "discord_user"
@@ -34,6 +36,7 @@ class DiscordUser(TimestampMixin, table=True):
         index=True,
     )
     is_birthday_leap: bool | None = Field(default=None)
+    birthday_timezone: str | None = Field(default=None, max_length=64)
 
 
 class DiscordMessage(CreatedAtMixin, table=True):

--- a/db/repository.py
+++ b/db/repository.py
@@ -52,7 +52,13 @@ async def upsert_user(
     username: str,
     birthday: datetime | None = None,
     is_birthday_leap: bool | None = None,
+    birthday_timezone: str | None = None,
 ) -> None:
+    """Write a user and all three birthday columns.
+
+    All three, together: they describe one birthday, and a caller that wrote two
+    of them would leave the third describing a different one.
+    """
     await _upsert(
         DiscordUser,
         {
@@ -60,6 +66,7 @@ async def upsert_user(
             "username": username,
             "birthday": birthday,
             "is_birthday_leap": is_birthday_leap,
+            "birthday_timezone": birthday_timezone,
         },
         ["id"],
     )

--- a/docs/adr/0003-birthday-holds-the-next-occurrence.md
+++ b/docs/adr/0003-birthday-holds-the-next-occurrence.md
@@ -1,8 +1,8 @@
 # The birthday column holds the next occurrence, not a date of birth
 
 `discord_user.birthday` stores the next time we will greet someone, as an instant
-in UTC, and moves each year — it is not the day they were born, and it carries no
-birth year. Storing the parts instead (month, day, timezone) would make a date in
+in UTC alongside the `birthday_timezone` it was set in, and moves each year — it
+is not the day they were born, and it carries no birth year. Storing the parts instead (month, day, timezone) would make a date in
 the past unrepresentable rather than merely avoided, which is the stronger design;
 it was rejected because the birthday task finds due birthdays every fifteen
 minutes with an indexed range scan over that column (`birthday <= now`), and
@@ -15,13 +15,21 @@ Anything writing a birthday has to **ask for** the next occurrence rather than
 build a date. `/birthday set` built one, and for ten months of every leap year it
 built one that had already passed; that is what `next_birthday_on` exists to stop.
 
-The timezone is used to place the instant and then discarded, so the roll-forward
-in `next_birthday` can only bump the year on a UTC instant, which preserves
-neither the local date nor the local wall clock. How much that costs depends
-entirely on which year's transitions you measure, so no single figure describes
-it — rolling every zone and date forward once gives 201 of 598 zones affected
-across 2026, the same 201 across 2025, and 411 across 2027. `Africa/Casablanca`
-and `Africa/El_Aaiun` are joint-worst in 2026 at 228 dates each and unaffected in
-2027. Setting a birthday is exact; rolling one forward is not. Closing that gap
-means storing the timezone alongside the instant, which is a schema change and
-has not been made — issue #12 carries the measurements.
+The timezone was originally used to place the instant and then discarded, so the
+roll-forward in `next_birthday` could only bump the year on a UTC instant, which
+preserves neither the local date nor the local wall clock. How much that cost
+depended entirely on which year's transitions you measured, so no single figure
+described it — rolling every zone and date forward once gave 201 of 598 zones
+affected across 2026, the same 201 across 2025, and 411 across 2027.
+
+`birthday_timezone` closes that gap, and is the whole reason the column exists:
+`next_birthday` reads the local date back off the instant and asks
+`next_birthday_on` for the parts, so both directions now run the same
+construction and the same sweep reports zero wrong local days and zero wrong
+local times in 2025, 2026 and 2027 alike. Issue #12 carries the measurements.
+
+The column is nullable and null on every row written before it, because there is
+no timezone to backfill from; those rows keep bumping the year until the person
+sets their birthday again. Storing the parts is still the stronger design and
+still rejected, for the range-scan reason above — the column only **adds** to
+the row, so the indexed `birthday <= now` scan is untouched.

--- a/migrations/versions/20260909_1615_0005_add_birthday_timezone.py
+++ b/migrations/versions/20260909_1615_0005_add_birthday_timezone.py
@@ -1,0 +1,29 @@
+"""Store the timezone a birthday was set in.
+
+The roll-forward had nothing to rebuild a local date in, so it bumped the year
+on a UTC instant and greeted 201 of 598 zones on the wrong local day - issue #12.
+Nullable, and null on every existing row: there is no timezone to backfill from,
+and null keeps the old behaviour until the person sets their birthday again.
+
+Revision ID: 0005
+Revises: 0004
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "discord_user",
+        sa.Column("birthday_timezone", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("discord_user", "birthday_timezone")

--- a/services/birthday.py
+++ b/services/birthday.py
@@ -1,9 +1,9 @@
 """When a birthday next falls.
 
-One rule answers that, asked two ways: next_birthday_on when it is being set and
-the timezone is still known, next_birthday when it is being rolled forward and
-it is not. Two implementations of this disagreed once and wrote dates that had
-already passed.
+One rule answers that, asked two ways: next_birthday_on from the parts, when a
+birthday is being set, and next_birthday from a stored instant, when one is
+being rolled forward. Two implementations of this disagreed once and wrote dates
+that had already passed, so the second asks the first wherever it can.
 """
 
 from calendar import isleap
@@ -32,15 +32,25 @@ def is_leap_day(month: Months, day: int) -> bool:
     return month == Months.February and day == 29
 
 
-def next_birthday(birthday: datetime, is_leap: bool, after: DateTime) -> DateTime:
+def next_birthday(
+    birthday: datetime, is_leap: bool, after: DateTime, timezone: str | None = None
+) -> DateTime:
     """The next occurrence of a stored birthday, strictly after ``after``.
 
-    A stored birthday is a UTC instant for one particular year, so advancing it
-    is a year bump; 29 February has to land on a leap year to exist at all.
+    With the zone it was set in, the local date is read back off the instant and
+    ``next_birthday_on`` answers from the parts, as it did when the birthday was
+    set. Without one there is nothing to construct a local date in, so advancing
+    a UTC instant is a year bump - which preserves neither the local day nor
+    local midnight across a zone's transitions, and is why the column exists
+    (issue #12). ``None`` is every row written before it did.
     """
     moment = pendulum.instance(birthday)
     if moment > after:
         return moment
+
+    if timezone is not None:
+        local = moment.in_tz(timezone)
+        return next_birthday_on(Months(local.month), local.day, timezone, after)
 
     # The flag is the authority, but a 29 February instant cannot be replaced
     # into a common year whatever the flag says.


### PR DESCRIPTION
next_birthday bumped the year on a UTC instant, which preserves neither the local day nor local midnight: rolling every zone and calendar date forward once put 997 of 218,868 pairs on the wrong local day and 1,436 more at the wrong local time, across 114 zones. Europe/London's 31 October rolled to 30 October 23:00 in five years out of six.

The information to do it properly was thrown away rather than absent — /birthday set knew the timezone and discarded it. discord_user now keeps it in a nullable birthday_timezone, and next_birthday reads the local date back off the instant and hands the parts to next_birthday_on, so both directions run the one construction that was already correct. The same sweep now reports zero wrong days and zero wrong times in 2025, 2026 and 2027 alike.

Existing rows have no zone to backfill from, so null keeps today's behaviour until the person sets their birthday again, and /birthday remove clears all three columns because upsert_user writes all three together.

Closes #12

## Summary by Sourcery

Store each birthday's setting timezone and use it to preserve the intended local date and time when rolling the birthday forward.

New Features:
- Preserve the timezone used when a birthday is set so future roll-forwards retain the correct local date and time.

Bug Fixes:
- Correct birthday roll-forwards across timezone transitions instead of advancing the stored UTC instant directly.
- Handle obsolete stored timezone names by clearing them and notifying the user rather than leaving birthdays permanently stuck.

Enhancements:
- Keep birthday timestamp, leap-day state, and timezone synchronized through user updates and removals.
- Maintain legacy behavior for existing birthday records without a stored timezone.

Build:
- Add an optional birthday_timezone column through a new database migration.

Documentation:
- Update birthday behavior, schema, and architectural documentation to describe timezone-aware roll-forwards and legacy fallback behavior.