### PR TITLE
chore: Retire the public Discord invite from !discord

### DIFF
--- a/migrations/versions/20260909_1730_0006_retire_discord_invite.py
+++ b/migrations/versions/20260909_1730_0006_retire_discord_invite.py
@@ -33,8 +33,8 @@ _twitch_command_component = sa.table(
 _OLD_DISCORD = "https://discord.gg/tkJyNJH2k7 Come join us and hang out! This is also where all my updates on streams and whatnot go"
 _NEW_DISCORD = "Due to an influx of bots, the Discord link is no longer public. Moots and friends can DM me or a mod directly to join the server. Sorry for the inconvenience!"
 
-# The positions 0002 gave them; !everything sorts on position, so removing two
-# leaves gaps and no reordering.
+# The positions 0002 gave them, which only the downgrade needs: !everything sorts
+# on position, so removing two leaves gaps and no reordering.
 _DROPPED_COMPONENTS = [
     {"parent_name": "everything", "child_name": "kofi", "position": 2},
     {"parent_name": "everything", "child_name": "throne", "position": 3},
@@ -56,6 +56,10 @@ def _set_discord_message(new: str, old: str) -> None:
 
 def upgrade() -> None:
     _set_discord_message(_NEW_DISCORD, _OLD_DISCORD)
+    # Matched on (parent_name, child_name), which is unique, so this removes the
+    # one link whatever position it has been moved to. Guarding it on position
+    # instead — the rule for an UPDATE — would make the revision a silent no-op
+    # on a reordered fanout, which is !everything still naming !kofi.
     op.execute(
         sa.delete(_twitch_command_component).where(
             _twitch_command_component.c.parent_name == "everything",

--- a/migrations/versions/20260909_1730_0006_retire_discord_invite.py
+++ b/migrations/versions/20260909_1730_0006_retire_discord_invite.py
@@ -1,0 +1,73 @@
+"""Retire the public Discord invite, and drop kofi/throne from !everything.
+
+The permanent invite is gone: it was drawing bot accounts, so joining is now by
+asking a person. !kofi and !throne stay as commands and just stop being part of
+the !everything fanout.
+
+Revision ID: 0006
+Revises: 0005
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import insert
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_twitch_command_response = sa.table(
+    "twitch_command_response",
+    sa.column("command_name", sa.String),
+    sa.column("position", sa.Integer),
+    sa.column("message", sa.Text),
+)
+_twitch_command_component = sa.table(
+    "twitch_command_component",
+    sa.column("parent_name", sa.String),
+    sa.column("child_name", sa.String),
+    sa.column("position", sa.Integer),
+)
+
+_OLD_DISCORD = "https://discord.gg/tkJyNJH2k7 Come join us and hang out! This is also where all my updates on streams and whatnot go"
+_NEW_DISCORD = "Due to an influx of bots, the Discord link is no longer public. Moots and friends can DM me or a mod directly to join the server. Sorry for the inconvenience!"
+
+# The positions 0002 gave them; !everything sorts on position, so removing two
+# leaves gaps and no reordering.
+_DROPPED_COMPONENTS = [
+    {"parent_name": "everything", "child_name": "kofi", "position": 2},
+    {"parent_name": "everything", "child_name": "throne", "position": 3},
+]
+
+
+def _set_discord_message(new: str, old: str) -> None:
+    # Guarded on the text it replaces, so a message edited in the database stays.
+    op.execute(
+        sa.update(_twitch_command_response)
+        .where(
+            _twitch_command_response.c.command_name == "discord",
+            _twitch_command_response.c.position == 0,
+            _twitch_command_response.c.message == old,
+        )
+        .values(message=new)
+    )
+
+
+def upgrade() -> None:
+    _set_discord_message(_NEW_DISCORD, _OLD_DISCORD)
+    op.execute(
+        sa.delete(_twitch_command_component).where(
+            _twitch_command_component.c.parent_name == "everything",
+            _twitch_command_component.c.child_name.in_(["kofi", "throne"]),
+        )
+    )
+
+
+def downgrade() -> None:
+    _set_discord_message(_OLD_DISCORD, _NEW_DISCORD)
+    op.execute(
+        insert(_twitch_command_component)
+        .values(_DROPPED_COMPONENTS)
+        .on_conflict_do_nothing()
+    )


### PR DESCRIPTION
The permanent invite was drawing bot accounts, so it is gone and joining is by asking a person. !kofi and !throne leave the !everything fanout; both keep their own commands and responses.

The UPDATE is guarded on the text 0002 seeded, so a message edited in the database is left alone. Removing two components leaves gaps at positions 2 and 3, which command_components does not care about: it sorts on position.

## Summary by Sourcery

Retire the public Discord invite and stop including !kofi and !throne in !everything.

Enhancements:
- Retire the public Discord invite message and remove !kofi and !throne from the !everything command fanout while preserving both commands independently.

Chores:
- Add a reversible database migration that updates only the original Discord response and safely restores the invite and fanout links on downgrade.