### PR TITLE
docs: Fix the language for autoshoutouts and how a session ends

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,15 +86,45 @@ stream forever — and leaves the newer alert's row alone.
 _Avoid_: stale, replaced, orphaned
 
 **Stream session**:
-The main broadcaster being live. At most one at a time, and it owns the
-**shoutout queue** and the ad-break notification. Distinct from a **live alert**,
-which exists per broadcaster.
-_Avoid_: broadcast, live session, stream run
+The main broadcaster being live, and the single answer to whether the bot is
+live. At most one at a time, and it owns every piece of state that lasts exactly
+one stream — the **shoutout queue**, the ad-break notification and which
+**autoshoutout list** members are **spent** — all of it in memory. Distinct from
+a **live alert**, which exists per broadcaster and is kept in Postgres because it
+names a Discord message that has to outlive a redeploy.
+_Avoid_: broadcast, live session, stream run, session manager
 
 **Shoutout queue**:
-The pending `!so` targets, drained at a rate Helix accepts. Active only for the
-duration of a **stream session**.
+The pending shoutout targets, drained at a rate Helix accepts by one task that
+runs for the life of the process. Each pass asks the **stream session** whether
+it may send and sleeps if not; the queue has no lifetime of its own and no
+opinion about who is live.
 _Avoid_: shoutout list, so queue
+
+**Autoshoutout**:
+A shoutout a **stream session** gives unprompted, the first time someone on the
+**autoshoutout list** chats, raids or redeems. Never what a mod's `!so` produces:
+that is a manual shoutout, and it spends nothing.
+_Avoid_: auto SO, automatic shoutout, greeting
+
+**Autoshoutout list**:
+The Twitch users due an **autoshoutout**, keyed by Twitch user id so a rename
+cannot drop anyone. Held in Postgres and curated with `!aso` and `!unaso`, so it
+outlives any one **stream session**.
+_Avoid_: roster, auto list, shoutout list (see **shoutout queue**)
+
+**Spent**:
+Said of an **autoshoutout list** member who has had their **autoshoutout** this
+**stream session** — at most one each, however many times they chat. `!aso`
+spends it, because it shouts them out as it adds them; a manual `!so` does not.
+_Avoid_: seen, done, greeted, shouted
+
+**Settled**:
+Said of a chatter this **stream session** has already resolved: either **spent**,
+or looked up and found not to be on the **autoshoutout list**. Holding both
+answers in one word is what keeps the list from being queried again for every
+line the same person types.
+_Avoid_: cached, checked, known
 
 ### Birthdays
 
@@ -188,6 +218,17 @@ The webhook cannot identify which stream ended — Twitch's `stream.offline`
 payload carries no stream id — so it can only wake the updater, which re-checks
 Helix and, if it is **superseded**, closes its own message without touching the
 newer alert's row.
+
+**"Closing" answers two questions, not one.** Closing a **live alert** and
+standing a **stream session** down are different decisions about different
+scopes, and they are still one code path — which is how a session outlives its
+stream whenever no alert row exists to close. Resolved in language ahead of the
+code: the **alert updater** remains the only closer *of an alert*, per ADR 0001;
+the **stream session** ends itself, woken by `stream.offline` and confirmed
+against Helix. A
+`stream.offline` payload names no stream, which is fatal to the alert question
+and irrelevant to the session one, because there is only ever one session and it
+belongs to a broadcaster the bot already knows.
 
 ## Example dialogue
 

--- a/docs/adr/0004-the-stream-session-ends-itself.md
+++ b/docs/adr/0004-the-stream-session-ends-itself.md
@@ -2,21 +2,30 @@
 
 A **stream session** owns everything that lasts exactly one stream — the
 **shoutout queue**, the ad-break notification, and which **autoshoutout list**
-members are **spent** — so the only thing that may stand it down is Helix
-confirming the broadcaster is gone. `stream.offline` wakes it; the session
-re-checks `get_stream` and ends only on a confirmed answer, and only if it still
-names the stream the check was started for. That last clause is not decoration:
+members are **spent** — so the only thing that may *end* one is Helix confirming
+the broadcaster is gone. `stream.offline` wakes it; the session re-checks
+`get_stream` and ends only on a confirmed answer, and only if it still names the
+stream the check was started for. That last clause is not decoration:
 `stream_online` can sit in `_wait_for_stream_info` for a minute before `began()`
 runs, so a stream that comes straight back can easily begin while the previous
 one's offline check is still in flight, and an unguarded check would stand down
 the session that had just replaced it.
 
+Ending a session and beginning one are separate transitions, and only the first
+is Helix's to decide. `began()` and `resume()` establish a session and discard
+whatever a previous one left behind, because that state described a stream that
+is over by definition: a reset, not a teardown, and the bot is live on both
+sides of it. The two rules therefore do not compete. A reconnect arriving while
+an offline check is still in flight supersedes it, by the stream id above; one
+arriving with no check outstanding simply starts clean. Nothing but Helix ever
+leaves the bot with no session at all, which is the property this ADR is about.
+
 This reads like a contradiction of ADR 0001 and is not. That decision is about
-which *alert* a `stream.offline` refers to, and the payload carrying no stream id
-makes the question unanswerable from the webhook. The session has no such
+which *alert* a `stream.offline` refers to, and the payload carrying no stream
+id makes the question unanswerable from the webhook. The session has no such
 ambiguity: there is at most one, for a broadcaster named in configuration, so
-"which session ended" has only ever had one answer. Closing an alert and ending a
-session are different decisions about different scopes, and only the first of
+"which session ended" has only ever had one answer. Closing an alert and ending
+a session are different decisions about different scopes, and only the first of
 them needs a stream id.
 
 ## Considered options
@@ -26,29 +35,31 @@ them needs a stream id.
   the session's correctness depend on a `live_alert` row existing, and three
   paths end an updater without ever reaching that branch: `_decide` returns
   `STOP` when the row is missing, `_run` returns after
-  `_MAX_INCONCLUSIVE_CYCLES`, and a failed `announce()` starts no updater at all.
-  In each, the stream ends and `shoutout_queue.activated` stays true — harmless
-  when the only cost was a drainer spinning on an empty queue, and not harmless
-  once **spent** hangs off the same flag, because then a list member gets one
-  **autoshoutout** ever rather than one per stream.
+  `_MAX_INCONCLUSIVE_CYCLES`, and a failed `announce()` starts no updater at
+  all. In each, the stream ends and `shoutout_queue.activated` stays true —
+  harmless when the only cost was a drainer spinning on an empty queue, and not
+  harmless once **spent** hangs off the same flag, because then a list member
+  gets one **autoshoutout** ever rather than one per stream.
 - **`stream.offline` ends the session directly** — no Helix round trip, and it
-  treats a brief disconnect as the end of the stream: the queue is dumped and the
-  pending shoutouts with it, moments before `stream.online` starts a new session.
+  treats a brief disconnect as the end of the stream: the queue is dumped and
+  the pending shoutouts with it, moments before `stream.online` starts a new
+  session.
 - **A periodic Helix heartbeat while active** — ends the session even if the
   `stream.offline` webhook never arrives, which is a real risk given that
   subscription is one of the five provisioned outside this repo. Rejected for
   now as a polling loop that mostly re-asks what the alert updater already asks
   Helix about the main broadcaster; the wake covers the ordinary case.
 - **Wake on `stream.offline`, confirm against Helix** — chosen. It reuses the
-  pattern ADR 0001 established rather than inventing one, survives a
-  disconnect-and-reconnect without losing the queue, and costs no poll.
+  pattern ADR 0001 established rather than inventing one, survives a stream
+  dropping and coming straight back without losing the queue, and costs no poll.
 
 ## Consequences
 
 An undeliverable `stream.offline` subscription now leaves the session up rather
-than merely delaying an alert. Two things bound that: `began()` resets the
-session's state outright, so the next `stream.online` recovers it whatever
-happened before, and the hourly `recheck_subscriptions` loop reports the
-subscription as **undeliverable** in the **admin channel**. If that proves too
-thin in practice, the heartbeat above is the next step and does not require this
-decision to be revisited.
+than merely delaying an alert. Two things bound that: the next `stream.online`
+starts a session clean whatever the previous one left behind, so the damage is
+confined to the gap between two streams rather than compounding across them, and
+the hourly `recheck_subscriptions` loop reports the subscription as
+**undeliverable** in the **admin channel**. If that proves too thin in practice,
+the heartbeat above is the next step and does not require this decision to be
+revisited.

--- a/docs/adr/0004-the-stream-session-ends-itself.md
+++ b/docs/adr/0004-the-stream-session-ends-itself.md
@@ -1,0 +1,54 @@
+# The stream session ends itself, and a live alert does not end it
+
+A **stream session** owns everything that lasts exactly one stream — the
+**shoutout queue**, the ad-break notification, and which **autoshoutout list**
+members are **spent** — so the only thing that may stand it down is Helix
+confirming the broadcaster is gone. `stream.offline` wakes it; the session
+re-checks `get_stream` and ends only on a confirmed answer, and only if it still
+names the stream the check was started for. That last clause is not decoration:
+`stream_online` can sit in `_wait_for_stream_info` for a minute before `began()`
+runs, so a stream that comes straight back can easily begin while the previous
+one's offline check is still in flight, and an unguarded check would stand down
+the session that had just replaced it.
+
+This reads like a contradiction of ADR 0001 and is not. That decision is about
+which *alert* a `stream.offline` refers to, and the payload carrying no stream id
+makes the question unanswerable from the webhook. The session has no such
+ambiguity: there is at most one, for a broadcaster named in configuration, so
+"which session ended" has only ever had one answer. Closing an alert and ending a
+session are different decisions about different scopes, and only the first of
+them needs a stream id.
+
+## Considered options
+
+- **The alert updater ends the session** — what the code did, at
+  `live_alert._cycle`, on `_Action.CLOSE` with a confirmed-gone stream. It made
+  the session's correctness depend on a `live_alert` row existing, and three
+  paths end an updater without ever reaching that branch: `_decide` returns
+  `STOP` when the row is missing, `_run` returns after
+  `_MAX_INCONCLUSIVE_CYCLES`, and a failed `announce()` starts no updater at all.
+  In each, the stream ends and `shoutout_queue.activated` stays true — harmless
+  when the only cost was a drainer spinning on an empty queue, and not harmless
+  once **spent** hangs off the same flag, because then a list member gets one
+  **autoshoutout** ever rather than one per stream.
+- **`stream.offline` ends the session directly** — no Helix round trip, and it
+  treats a brief disconnect as the end of the stream: the queue is dumped and the
+  pending shoutouts with it, moments before `stream.online` starts a new session.
+- **A periodic Helix heartbeat while active** — ends the session even if the
+  `stream.offline` webhook never arrives, which is a real risk given that
+  subscription is one of the five provisioned outside this repo. Rejected for
+  now as a polling loop that mostly re-asks what the alert updater already asks
+  Helix about the main broadcaster; the wake covers the ordinary case.
+- **Wake on `stream.offline`, confirm against Helix** — chosen. It reuses the
+  pattern ADR 0001 established rather than inventing one, survives a
+  disconnect-and-reconnect without losing the queue, and costs no poll.
+
+## Consequences
+
+An undeliverable `stream.offline` subscription now leaves the session up rather
+than merely delaying an alert. Two things bound that: `began()` resets the
+session's state outright, so the next `stream.online` recovers it whatever
+happened before, and the hourly `recheck_subscriptions` loop reports the
+subscription as **undeliverable** in the **admin channel**. If that proves too
+thin in practice, the heartbeat above is the next step and does not require this
+decision to be revisited.


### PR DESCRIPTION
Names the concepts the autoshoutout work needs before any of it is written: an **autoshoutout** is what a stream session gives unprompted and a manual !so is not, an **autoshoutout list** outlives any one session, **spent** is the once-per-session rule in a word, and **settled** holds "spent" and "not on the list" together, which is what keeps the list from being queried for every line a regular types.

Rewrites **stream session** and **shoutout queue** around a decision the code has not caught up with. CONTEXT.md already said a session owns the shoutout queue and the ad-break notification; the code answers "are we live" three different ways instead, and the one everybody asks lives on the queue. The entry now says what a session is for, and the queue's says it has no lifetime of its own.

ADR 0004 records why the session ends itself rather than waiting to be ended by the alert updater, and why that is not a contradiction of ADR 0001: a stream.offline payload carries no stream id, which is fatal to "which alert closes" and irrelevant to "which session ended", because there is only ever one and its broadcaster is configuration. The bug it came from is real today — three paths end an updater without reaching the branch that stands the session down, so a session can outlive its stream.

Language ahead of the code, as the _create_offline_embed entry already was. Implementation is #20, #21 and #22.

The two Verity surfaces disagreed about this commit and neither is a code gate. `verity analyze` answered "No analyzable files changed" — a PASS that reviewed nothing, because .md is not in ANALYZABLE_EXTENSIONS. The pre-commit hook then reported PASS having reviewed both files by name. Recorded rather than resolved: whichever is right, no Python changed here, so nothing was gated in the sense CLAUDE.md means.

## Summary by Sourcery

Clarify autoshoutout terminology and establish the stream session as the authority for per-stream state and lifecycle.

Bug Fixes:
- Clarify the session-lifecycle decision that prevents stream sessions from outliving the broadcaster when alert-updater paths terminate without closing the session.

Enhancements:
- Define and standardize the concepts of autoshoutouts, autoshoutout lists, spent members, and settled chatters.
- Clarify that stream sessions own per-stream state while the shoutout queue is process-lived and consults session state to decide whether it may send.
- Distinguish ending a stream session from closing a live alert, including why each has different ownership and identity requirements.

Documentation:
- Add ADR 0004 documenting why sessions end after a confirmed Helix offline check and how reconnects supersede stale checks.
- Update project context documentation with the revised stream-session, shoutout-queue, and autoshoutout terminology and lifecycle guidance.