### PR TITLE
Collapse small duplications, retire the models barrel, and validate the outgoing raid login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,20 @@ its reason.
 <!-- verity-memory:preserve -->
 
 
+
 <!-- Add binding, hand-curated guidance here; it survives Verity regeneration. -->
+
+## Never report a false positive without `--file`
+
+The generated section above says to use `verity feedback finding <run-id>
+<pattern-id> false_positive` for a pattern-level false positive. Always add
+`--file <path>` (and `--line`). Without it the suppression is scoped to
+`**/*.py` — every Python file — and it cannot be listed or removed from the
+CLI afterwards. This has already blinded `type-safety` on this repo once; the
+reproduction and the consequences are in `VERITY.md`.
+
+Before treating a Verity run as clean, read `suppressions_applied` in its JSON.
+Zero findings and a blinded pattern look identical.
 
 ## Verity runs before the commit, never after
 

--- a/VERITY.md
+++ b/VERITY.md
@@ -81,6 +81,43 @@ Note that the IDs this adapter defines carry a slug suffix
 (`Ruff_ANN001_missing-type-function-argument`, not `Ruff_ANN001`). A wrong ID disables
 the tool **silently**, so never hand-author one — derive it with `--list` and validate.
 
+### Reporting a false positive: always pass `--file`
+
+`verity feedback finding <run-id> <pattern-id> false_positive` **without
+`--file` suppresses that pattern across `**/*.py`** — the whole language, not
+the finding you reported. It is not obvious from the output, and there is no
+CLI way to list or remove a suppression afterwards; `feedback finding ...
+useful` does not reverse it and `verity config get` does not show it.
+
+Demonstrated on 2026-09-10: three unscoped `false_positive` reports for
+`type-safety` left a probe file containing a genuinely undefined name **and** a
+function annotated `-> int` returning a `str` reviewing as `PASS` with zero
+findings and `suppressions_applied: [{pattern_id: type-safety, file_glob:
+"**/*.py", count: 2}]`. Reported upstream; until it is cleared, Verity's
+`type-safety` dimension is blind on this repo and `uvx pyright` plus
+`uvx ruff check` are the cover — both catch exactly what it now swallows.
+
+So: pass `--file` (and `--line`), and before trusting a clean run, read
+`suppressions_applied`. Zero findings is indistinguishable from a blinded
+pattern — the same failure shape as a wrong pattern ID above.
+
+### Why `Ruff_F821_undefined-name` is not in the pattern list
+
+Codacy's Ruff runs below `--target-version py314`, so it reports F821 on a
+class annotating itself in its own body —
+`_instance: ClassVar[TwitchShoutoutQueue | None] = None` inside
+`class TwitchShoutoutQueue`. On Python 3.14 that is correct code: PEP 649
+compiles annotations into a lazy `__annotate__` thunk, so the class body never
+evaluates the name. The modules import and `__annotations__` resolves.
+
+`ruff check --target-version py314` passes; py313 and below report it. The
+repo's `requires-python = ">=3.14.7"` makes the project's own Ruff infer py314,
+which is why `uvx ruff check` is clean and Verity's was not, and
+`.codacy/codacy.config.json` exposes no target-version to fix it with. F821 was
+therefore removed from the list rather than suppressed: the project's own Ruff
+and pyright both enforce it correctly, so nothing is lost, and the recurring
+false positive no longer invites another suppression.
+
 ### Two Windows workarounds this setup depends on
 
 Both are upstream bugs in the current releases (`@codacy/verity-cli` 0.31.1,

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,4 +1,4 @@
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
 
 import discord
 import pendulum
@@ -31,15 +31,17 @@ class Events(Cog):
         self.bot = bot
 
     async def _safe_db_operation(
-        self,
-        operation: str,
-        func: Callable[..., Awaitable[object]],
-        *args: object,
-        **kwargs: object,
+        self, operation: str, write: Awaitable[object]
     ) -> None:
-        """Run a database write, reporting failures instead of raising."""
+        """Run a database write, reporting failures instead of raising.
+
+        Takes the call already made rather than a function and its arguments.
+        Passed as `*args: object` they were checked against nothing, so
+        upsert_message's six could be reordered and pyright would agree; written
+        out at the call site they are checked as ordinary arguments.
+        """
         try:
-            await func(*args, **kwargs)
+            await write
         except Exception as e:  # noqa: BLE001
             await report(e, f"Failed to {operation}")
 
@@ -60,13 +62,14 @@ class Events(Cog):
         guild = message.guild
         await self._safe_db_operation(
             f"store message {message.id}",
-            repository.upsert_message,
-            message.id,
-            message.content,
-            config.setting("guild_id") if guild is None else guild.id,
-            message.author.id,
-            message.channel.id,
-            [attachment.url for attachment in message.attachments],
+            repository.upsert_message(
+                message.id,
+                message.content,
+                config.setting("guild_id") if guild is None else guild.id,
+                message.author.id,
+                message.channel.id,
+                [attachment.url for attachment in message.attachments],
+            ),
         )
 
     @Cog.listener()
@@ -108,9 +111,7 @@ class Events(Cog):
 
             await self._safe_db_operation(
                 f"insert user {member.name} ({member.id})",
-                repository.upsert_username,
-                member.id,
-                member.name,
+                repository.upsert_username(member.id, member.name),
             )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_member_join event")
@@ -135,8 +136,7 @@ class Events(Cog):
 
             await self._safe_db_operation(
                 f"remove user {member.name} ({member.id})",
-                repository.delete_user,
-                member.id,
+                repository.delete_user(member.id),
             )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_member_remove event")
@@ -262,8 +262,7 @@ class Events(Cog):
 
             await self._safe_db_operation(
                 f"delete message {payload.message_id}",
-                repository.delete_message,
-                payload.message_id,
+                repository.delete_message(payload.message_id),
             )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_message_delete event")
@@ -286,8 +285,7 @@ class Events(Cog):
             for message_id in payload.message_ids:
                 await self._safe_db_operation(
                     f"delete message {message_id}",
-                    repository.delete_message,
-                    message_id,
+                    repository.delete_message(message_id),
                 )
         except Exception as e:  # noqa: BLE001
             await report(e, "Fatal error with on_raw_bulk_message_delete event")

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -72,7 +72,7 @@ class Events(Cog):
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
         try:
-            if message.author == self.bot.user:
+            if self._is_bot_message(message):
                 return
 
             await self._store_message(message)
@@ -194,17 +194,20 @@ class Events(Cog):
         """Check if a member is currently timed out."""
         return timeout_until is not None and timeout_until > pendulum.now()
 
-    async def _is_bot_message(self, payload: RawMessageUpdateEvent) -> bool:
-        """Check if the message was sent by the bot."""
-        return payload.message.author == self.bot.user or (
-            payload.cached_message is not None
-            and payload.cached_message.author == self.bot.user
-        )
+    def _is_bot_message(self, *messages: Message | None) -> bool:
+        """Whether any of these is a message the bot itself sent.
+
+        Variadic because the three callers hold different things: a live
+        Message, an edit payload's before and after, and a delete payload's
+        cached copy alone. Spelling it three times is how the delete path came
+        to check only half of what the edit path checks.
+        """
+        return any(m is not None and m.author == self.bot.user for m in messages)
 
     @Cog.listener()
     async def on_raw_message_edit(self, payload: RawMessageUpdateEvent) -> None:
         try:
-            if await self._is_bot_message(payload):
+            if self._is_bot_message(payload.message, payload.cached_message):
                 return
 
             before = payload.cached_message
@@ -231,10 +234,7 @@ class Events(Cog):
     @Cog.listener()
     async def on_raw_message_delete(self, payload: RawMessageDeleteEvent) -> None:
         try:
-            if (
-                payload.cached_message is not None
-                and payload.cached_message.author == self.bot.user
-            ):
+            if self._is_bot_message(payload.cached_message):
                 return
 
             user_who_deleted = await self._get_audit_user(

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -18,15 +18,13 @@ from constants import (
     TWITCH_MESSAGE_TYPE,
 )
 from errors import notify, report
-from models import (
-    ChannelAdBreakBeginEventSub,
-    ChannelChatMessageEventSub,
-    ChannelFollowEventSub,
-    ChannelModerateEventSub,
-    ChannelRaidEventSub,
-    StreamOfflineEventSub,
-    StreamOnlineEventSub,
-)
+from models.twitch_event_subs.channel_ad_break_begin import ChannelAdBreakBeginEventSub
+from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
+from models.twitch_event_subs.channel_follow import ChannelFollowEventSub
+from models.twitch_event_subs.channel_moderate import ChannelModerateEventSub
+from models.twitch_event_subs.channel_raid import ChannelRaidEventSub
+from models.twitch_event_subs.stream_offline import StreamOfflineEventSub
+from models.twitch_event_subs.stream_online import StreamOnlineEventSub
 from services.twitch import events
 from services.twitch.signature import (
     get_hmac,

--- a/controller/twitch_oauth.py
+++ b/controller/twitch_oauth.py
@@ -13,7 +13,7 @@ from fastapi.responses import RedirectResponse
 from config import settings
 from constants import TokenType
 from errors import notify, report
-from models import RefreshResponse, TokenValidationResponse
+from models.auth.auth_response import RefreshResponse, TokenValidationResponse
 from services.http_client import client
 from services.twitch.oauth import (
     authorization_url,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,42 +1,6 @@
-from .auth.auth_response import AuthResponse, RefreshResponse, TokenValidationResponse
-from .twitch_api_responses.ad_schedule import AdSchedule, AdScheduleResponse
-from .twitch_api_responses.channel import Channel, ChannelResponse
-from .twitch_api_responses.stream import Stream, StreamResponse
-from .twitch_api_responses.subscription import (
-    Subscription,
-    SubscriptionResponse,
-)
-from .twitch_api_responses.user import User, UserResponse
-from .twitch_api_responses.video import Video, VideoResponse
-from .twitch_event_subs.channel_ad_break_begin import ChannelAdBreakBeginEventSub
-from .twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
-from .twitch_event_subs.channel_follow import ChannelFollowEventSub
-from .twitch_event_subs.channel_moderate import ChannelModerateEventSub
-from .twitch_event_subs.channel_raid import ChannelRaidEventSub
-from .twitch_event_subs.stream_offline import StreamOfflineEventSub
-from .twitch_event_subs.stream_online import StreamOnlineEventSub
+"""The shapes Twitch sends and returns, described with Pydantic.
 
-__all__ = [
-    "AdSchedule",
-    "AdScheduleResponse",
-    "AuthResponse",
-    "Channel",
-    "ChannelAdBreakBeginEventSub",
-    "ChannelChatMessageEventSub",
-    "ChannelFollowEventSub",
-    "ChannelModerateEventSub",
-    "ChannelRaidEventSub",
-    "ChannelResponse",
-    "RefreshResponse",
-    "Stream",
-    "StreamOfflineEventSub",
-    "StreamOnlineEventSub",
-    "StreamResponse",
-    "Subscription",
-    "SubscriptionResponse",
-    "TokenValidationResponse",
-    "User",
-    "UserResponse",
-    "Video",
-    "VideoResponse",
-]
+Nothing is re-exported here: import from the module that owns the name, so a
+reader lands on the file that defines it rather than on a list of twenty-two.
+`db/models/` is the other model package, and holds the SQLModel tables.
+"""

--- a/models/twitch_event_subs/channel_chat_message.py
+++ b/models/twitch_event_subs/channel_chat_message.py
@@ -2,7 +2,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from .common import Badge, Message
+from .common.badge import Badge
+from .common.message import Message
 
 
 class ChannelChatMessageSubscription(BaseModel):

--- a/models/twitch_event_subs/common/__init__.py
+++ b/models/twitch_event_subs/common/__init__.py
@@ -1,7 +1,1 @@
-from .badge import Badge
-from .message import Message
-
-__all__ = [
-    "Badge",
-    "Message",
-]
+"""Fields that appear inside more than one EventSub payload."""

--- a/services/audit.py
+++ b/services/audit.py
@@ -18,10 +18,8 @@ from discord import (
     Message,
     Object,
     Role,
-    Thread,
     User,
 )
-from discord.abc import GuildChannel, PrivateChannel
 from discord.ext.commands import CommandError, Context
 from discord.utils import escape_markdown
 from pendulum import DateTime
@@ -34,11 +32,13 @@ from constants import (
 )
 from services.config import config
 from services.duration import get_age
-from services.present import get_channel_mention, get_discriminator, get_pfp
+from services.present import (
+    MentionableChannel,
+    get_channel_mention,
+    get_discriminator,
+    get_pfp,
+)
 from services.send import send_embed
-
-# Exactly what bot.get_channel hands back, which is what the message events carry.
-AuditChannel = GuildChannel | Thread | PrivateChannel | None
 
 # Discord rejects the whole embed if any one of these is exceeded, so they are
 # enforced here rather than trusted to the callers.
@@ -287,7 +287,7 @@ async def message_edited(after: Message, before_content: str | None) -> None:
         "embed_color_info",
     )
     _by(embed, after.author)
-    embed.set_footer(text=f"User ID: {after.author.id}").add_field(
+    embed.set_footer(text=f"ID: {after.author.id}").add_field(
         name="**Before**", value=_quoted(before_content), inline=False
     ).add_field(name="**After**", value=_said(after.content), inline=False)
     await _send(embed)
@@ -301,7 +301,7 @@ async def pin_changed(message: Message) -> None:
         "embed_color_info",
     )
     _by(embed, message.author)
-    embed.set_footer(text=f"User ID: {message.author.id}")
+    embed.set_footer(text=f"ID: {message.author.id}")
     await _send(embed)
 
 
@@ -312,7 +312,7 @@ async def message_deleted(
     message_id: int,
     author: User | Member,
     deleted_by: User | Member | None,
-    channel: AuditChannel,
+    channel: MentionableChannel,
 ) -> None:
     """One embed for the message, then one more for each attachment it carried."""
     channel_mention = get_channel_mention(channel)
@@ -348,7 +348,7 @@ async def message_deleted_uncached(
     content: str | None,
     message_id: int,
     deleted_by: User | Member | None,
-    channel: AuditChannel,
+    channel: MentionableChannel,
 ) -> None:
     """A deletion the bot has no copy of the message for, only the stored text."""
     mention = UNKNOWN_USER if deleted_by is None else deleted_by.mention
@@ -365,7 +365,7 @@ async def message_deleted_uncached(
 
 
 async def bulk_deleted(
-    *, count: int, deleted_by: User | Member | None, channel: AuditChannel
+    *, count: int, deleted_by: User | Member | None, channel: MentionableChannel
 ) -> None:
     embed = _embed(
         f"**Bulk Delete in {get_channel_mention(channel)}, {count} messages deleted**",
@@ -387,7 +387,7 @@ async def command_failed(ctx: Context, error: CommandError) -> None:
         "embed_color_info",
     )
     _by(embed, ctx.author)
-    embed.set_footer(text=f"User ID: {ctx.author.id}").add_field(
+    embed.set_footer(text=f"ID: {ctx.author.id}").add_field(
         name="**Command**",
         value=_said(ctx.message.content),
         inline=False,

--- a/services/config.py
+++ b/services/config.py
@@ -35,6 +35,11 @@ logger = logging.getLogger(__name__)
 _PLACEHOLDER = re.compile(r"\{(channel|role):([a-z0-9_]+)\}")
 _FORMAT_FIELD = re.compile(r"\{([^{}]*)\}")
 
+# Only reached when a colour key is missing from the settings table entirely;
+# a key that exists answers with its own row. It deliberately matches the
+# seeded embed_color_info, so a caller that names nothing looks like the rest.
+_FALLBACK_COLOR = 0x337FD5
+
 
 def _field_name(field: str) -> str:
     """The value a replacement field reads, without conversion or format spec."""
@@ -163,7 +168,7 @@ class ConfigCache:
     def setting(self, key: str, default: Any = None) -> Any:
         return self._settings.get(key, default)
 
-    def color(self, key: str, default: int = 0x337FD5) -> int:
+    def color(self, key: str, default: int = _FALLBACK_COLOR) -> int:
         value = self._settings.get(key, default)
         return int(value) if value is not None else default
 

--- a/services/roles.py
+++ b/services/roles.py
@@ -44,29 +44,27 @@ async def toggle_role(
 
 async def roles_button_pressed(interaction: Interaction, button: Button) -> None:
     guild_id = interaction.guild_id
-    member_id = interaction.user.id
     emoji = button.emoji
-    if not guild_id or not emoji:
-        await interaction.response.send_message(
-            config.template("discord_role_error"),
-            ephemeral=True,
-        )
-        return
-    res = await toggle_role(guild_id, member_id, emoji)
+
+    # A button with no emoji and a toggle that could not resolve the role are
+    # one answer to the presser: the reason is theirs to act on in neither case.
+    res = (
+        await toggle_role(guild_id, interaction.user.id, emoji)
+        if guild_id and emoji
+        else None
+    )
     if res is None:
         await interaction.response.send_message(
             config.template("discord_role_error"),
             ephemeral=True,
         )
         return
-    success, role = res
-    if not success:
-        await interaction.response.send_message(
-            config.template("discord_role_removed", role=role.mention),
-            ephemeral=True,
-        )
-        return
+
+    added, role = res
     await interaction.response.send_message(
-        config.template("discord_role_added", role=role.mention),
+        config.template(
+            "discord_role_added" if added else "discord_role_removed",
+            role=role.mention,
+        ),
         ephemeral=True,
     )

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -11,20 +11,12 @@ from typing import Literal
 from config import settings
 from constants import TokenType
 from errors import notify
-from models import (
-    AdSchedule,
-    AdScheduleResponse,
-    Channel,
-    ChannelResponse,
-    Stream,
-    StreamResponse,
-    Subscription,
-    SubscriptionResponse,
-    User,
-    UserResponse,
-    Video,
-    VideoResponse,
-)
+from models.twitch_api_responses.ad_schedule import AdSchedule, AdScheduleResponse
+from models.twitch_api_responses.channel import Channel, ChannelResponse
+from models.twitch_api_responses.stream import Stream, StreamResponse
+from models.twitch_api_responses.subscription import Subscription, SubscriptionResponse
+from models.twitch_api_responses.user import User, UserResponse
+from models.twitch_api_responses.video import Video, VideoResponse
 from services.config import config
 from services.twitch import helix
 from services.twitch.helix import HelixError

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -10,7 +10,7 @@ import re
 from collections.abc import Awaitable, Callable
 
 from errors import notify
-from models import ChannelChatMessageEventSub
+from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
 from services.config import config, safe_format
 from services.twitch import stream_session
 from services.twitch.api import get_channel, get_user_by_username

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -10,16 +10,14 @@ import logging
 import time
 
 from errors import notify, report
-from models import (
-    ChannelAdBreakBeginEventSub,
-    ChannelChatMessageEventSub,
-    ChannelFollowEventSub,
-    ChannelModerateEventSub,
-    ChannelRaidEventSub,
-    Stream,
-    StreamOfflineEventSub,
-    StreamOnlineEventSub,
-)
+from models.twitch_api_responses.stream import Stream
+from models.twitch_event_subs.channel_ad_break_begin import ChannelAdBreakBeginEventSub
+from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
+from models.twitch_event_subs.channel_follow import ChannelFollowEventSub
+from models.twitch_event_subs.channel_moderate import ChannelModerateEventSub
+from models.twitch_event_subs.channel_raid import ChannelRaidEventSub
+from models.twitch_event_subs.stream_offline import StreamOfflineEventSub
+from models.twitch_event_subs.stream_online import StreamOnlineEventSub
 from services.config import config
 from services.twitch import live_alert, stream_session
 from services.twitch.api import get_stream, get_user

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -176,24 +176,30 @@ async def channel_ad_break_begin(event_sub: ChannelAdBreakBeginEventSub) -> None
 
 async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
     try:
+        # Both logins are checked before anything is built from them, rather
+        # than after it is read back. Outbound, the login becomes a URL the bot
+        # posts in chat; inbound, it becomes a `!so <login>` line that returns
+        # through the chat webhook and is dispatched, so a value that cannot
+        # name a channel must not reach either. The payload is signed, which is
+        # why neither has ever fired - this is the boundary, not a doubt about
+        # Twitch, and it is the same one `!so` itself uses.
         if stream_session.is_main_broadcaster(event_sub.event.from_broadcaster_user_id):
-            twitch_url = (
-                f"https://www.twitch.tv/{event_sub.event.to_broadcaster_user_login}"
-            )
+            raided = event_sub.event.to_broadcaster_user_login
+            if not is_twitch_login(raided):
+                await notify(
+                    f"Said nothing about an outgoing raid to {raided!r}:"
+                    f" that cannot name a Twitch channel, so it cannot be a URL.",
+                    key="raid-out-bad-login",
+                )
+                return
             await say_template(
                 event_sub.event.from_broadcaster_user_id,
                 "twitch_raid_out",
                 name=event_sub.event.to_broadcaster_user_name,
-                url=twitch_url,
+                url=f"https://www.twitch.tv/{raided}",
             )
         elif stream_session.is_main_broadcaster(event_sub.event.to_broadcaster_user_id):
             raider = event_sub.event.from_broadcaster_user_login
-            # Checked before the line is built, not after it is read back. The
-            # shoutout is delivered by posting `!so <login>` into chat, which
-            # returns through the chat webhook and is dispatched, so a login
-            # that cannot name a channel must not reach a command at all. The
-            # payload is signed, which is why this has never fired - it is the
-            # boundary, not a doubt about Twitch.
             if not is_twitch_login(raider):
                 await notify(
                     f"Refused to shout out an incoming raid from {raider!r}:"

--- a/services/twitch/live_alert.py
+++ b/services/twitch/live_alert.py
@@ -16,7 +16,8 @@ from background import fire_and_forget
 from db import repository
 from db.models import LiveAlert
 from errors import notify, report
-from models import Stream, User
+from models.twitch_api_responses.stream import Stream
+from models.twitch_api_responses.user import User
 from services.send import send_embed
 from services.twitch.live_alert_cycle import Action, cycle
 from services.twitch.live_alert_embeds import (

--- a/services/twitch/live_alert_cycle.py
+++ b/services/twitch/live_alert_cycle.py
@@ -20,7 +20,9 @@ import pendulum
 from db import repository
 from db.models import LiveAlert
 from errors import notify, report
-from models import Stream, User, Video
+from models.twitch_api_responses.stream import Stream
+from models.twitch_api_responses.user import User
+from models.twitch_api_responses.video import Video
 from services.duration import get_age
 from services.send import edit_embed
 from services.twitch.api import get_channel, get_stream, get_stream_vod, get_user

--- a/services/twitch/live_alert_embeds.py
+++ b/services/twitch/live_alert_embeds.py
@@ -10,7 +10,10 @@ import pendulum
 from discord.ui import View
 from discord.utils import escape_markdown
 
-from models import Channel, Stream, User, Video
+from models.twitch_api_responses.channel import Channel
+from models.twitch_api_responses.stream import Stream
+from models.twitch_api_responses.user import User
+from models.twitch_api_responses.video import Video
 from services.config import config
 from services.twitch.signature import parse_rfc3339
 

--- a/services/twitch/shoutout_queue.py
+++ b/services/twitch/shoutout_queue.py
@@ -8,7 +8,7 @@ import pendulum
 
 from background import fire_and_forget
 from errors import notify, report
-from models import User
+from models.twitch_api_responses.user import User
 from services.twitch.api import get_user, send_shoutout
 from services.twitch.helix import HelixError
 

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -18,7 +18,7 @@ import pendulum
 
 from background import fire_and_forget
 from errors import notify, report
-from models import Stream
+from models.twitch_api_responses.stream import Stream
 from services.config import config
 from services.twitch.api import get_ad_schedule, get_stream
 from services.twitch.chat import say_template

--- a/services/twitch/token_manager.py
+++ b/services/twitch/token_manager.py
@@ -14,7 +14,7 @@ from constants import TokenType
 from db.models import OAuthToken
 from db.session import session_scope
 from errors import notify
-from models import AuthResponse, RefreshResponse
+from models.auth.auth_response import AuthResponse, RefreshResponse
 from services.http_client import client
 from services.twitch.oauth import configured_scopes
 

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -58,15 +58,15 @@ def build_embed(key: str) -> Embed:
 
 def role_panels(channel_key: str) -> list[tuple[Embed, RolePickerView, int]]:
     """Every embed destined for one channel, in stored order."""
-    panels = []
-    for key in config.embed_keys():
-        stored = config.embed(key)
-        if stored is None or stored.channel_key != channel_key:
-            continue
-        panels.append(
-            (build_embed(key), RolePickerView(key), config.channel(channel_key))
-        )
-    return panels
+    # config.channel stays inside: it raises for a key with no row, and hoisting
+    # it would turn "nothing is configured for this panel" from an empty list
+    # into a failed command.
+    return [
+        (build_embed(key), RolePickerView(key), config.channel(channel_key))
+        for key in config.embed_keys()
+        if (stored := config.embed(key)) is not None
+        and stored.channel_key == channel_key
+    ]
 
 
 def persistent_views() -> list[RolePickerView]:


### PR DESCRIPTION
Small consolidations found by an architecture review of the whole codebase, plus one real defect the review turned up. No behaviour changes except where noted.

## What's here

**`4afa65c` — five small duplications collapsed**

- One variadic, synchronous `_is_bot_message` replaces three spellings in `cogs/events.py`. The delete path had been re-inlining only half of what the edit path checked, and the predicate was `async` while awaiting nothing.
- `services/audit.py`'s own `AuditChannel` alias deleted in favour of `present.MentionableChannel`, the superset its only consumer already accepts.
- Three footers saying `User ID:` now say `ID:`, matching the eight that already did. The two composite footers that also carry a message id mean something different and keep their wording.
- `roles_button_pressed` gave four answers where there are two: a button with no emoji and a toggle that could not resolve the role are the same answer to the presser, and added/removed differ only in a template key.
- `ConfigCache.color`'s `0x337FD5` default is the seeded `embed_color_info` value written a second time; it is now named and commented.

**`87f12c9` — the `models/` barrel retired, and the database-write wrapper typed**

`models/__init__.py` re-exported twenty-two names, so `from models import Stream` landed a reader on a list rather than the file that defines it. `services/__init__.py` and `db/__init__.py` were reduced to docstrings for exactly this reason; `db/models/__init__.py` keeps its barrel because importing it registers the tables, and `models/` has no such excuse. Eleven consumers now import from the owning module, and the same rule retires `models/twitch_event_subs/common`.

`_safe_db_operation` took a function plus `*args: object`, so `upsert_message`'s six arguments were checked against nothing. It now takes the call already made. Confirmed by swapping two of those arguments and watching pyright raise two errors where it previously raised none.

**`4d233a1` — a real defect: the outgoing raid login was unvalidated**

`channel_raid` validated `from_broadcaster_user_login` before composing `!so <login>`, but interpolated `to_broadcaster_user_login` straight into a URL the bot posts in chat. Same handler, same payload, one branch guarded and one not. Both now go through `is_twitch_login`.

Found by reviewing the codebase as it stands rather than as a diff — that branch was not in any recent diff, so no commit gate had looked at it since it was written.

## Deliberately not done

The `Stream`/`LiveAlert` representation split (one value, four representations — #33 names it out of scope for the same reason) and `cogs/tasks.py`'s second held-back mechanism, whose "recovered" half is something `errors.py` cannot express and so needs a decision rather than a refactor.

## Verification

The four checks clean in order, gate readings taken while uncommitted, and three throwaway harnesses green (session lifecycle 13 checks, alert-wake independence, composite authorization). **There is no test suite, so none of this is tested** — it has not run against a real stream.

## Related

Follows #20. The wider survey that produced this is filed as #24–#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate repeated code and direct model imports while validating outgoing raid destinations before they are posted to chat.

Bug Fixes:
- Validate the destination Twitch login before constructing and posting an outgoing raid URL.

Enhancements:
- Consolidate duplicate bot-message checks, role-button responses, audit-channel typing, footer wording, and configuration defaults.
- Retire the general models barrel and update consumers to import model types from their owning modules.
- Type database write calls at their call sites so argument mismatches are checked statically.
- Simplify role-panel construction while preserving empty-configuration behavior.

Documentation:
- Document safe Verity false-positive reporting and identify the Python-version-specific Ruff false positive handling.