### PR TITLE
A failed startup arm now says which one failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The bookworm tags are frozen at an old uv whose newest 3.14 cannot satisfy
 # requires-python, so this follows trixie instead.
-FROM ghcr.io/astral-sh/uv:0.12.12-python3.14-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.12.13-python3.14-trixie-slim
 
 WORKDIR /app
 

--- a/init/bot_init.py
+++ b/init/bot_init.py
@@ -5,31 +5,37 @@ import discord
 from discord.ext.commands import Bot
 
 from background import fire_and_forget
-from errors import notify
+from errors import notify, report
 
 logger = logging.getLogger(__name__)
 
 _startup_announced = False
 
 
-async def restart_live_alert_tasks() -> None:
-    from services.twitch import live_alert
-
-    await live_alert.restore_all()
-
-
-async def resume_stream_session() -> None:
-    from services.twitch import stream_session
-
-    await stream_session.resume()
-
-
 async def run_background_tasks() -> None:
-    await asyncio.gather(
-        restart_live_alert_tasks(),
-        resume_stream_session(),
-        return_exceptions=True,
+    """Bring the per-process helpers back up, saying which one failed.
+
+    The arms are gathered so one cannot delay the other, and their results are
+    read: `return_exceptions=True` on its own is silence, because the gather
+    completes normally and `background._finished` sees nothing to report. An
+    unreachable database at boot would then leave every stored alert without an
+    updater for the life of the process with nothing said. `main()` reads its
+    cog-loading results the same way.
+
+    Each arm is named for what was lost rather than for the function that lost
+    it, because that is what the admin channel needs to act on.
+    """
+    # Deferred: both reach services.send, which imports this package for `bot`.
+    from services.twitch import live_alert, stream_session
+
+    arms = (
+        ("restore the live alert updaters", live_alert.restore_all()),
+        ("resume the stream session", stream_session.resume()),
     )
+    results = await asyncio.gather(*(arm for _, arm in arms), return_exceptions=True)
+    for (lost, _), result in zip(arms, results, strict=True):
+        if isinstance(result, Exception):
+            await report(result, f"Startup could not {lost}")
 
 
 class MyBot(Bot):

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -105,9 +105,10 @@ async def resume() -> None:
     difference is the whole reason this is not a second call to began().
     """
     try:
-        # Inside the guard: a broadcaster id that is missing or not a number
-        # raises here, and the gather(return_exceptions=True) upstream would
-        # swallow it, leaving the session down with nothing said.
+        # Still guarded now that the caller reports a failed startup arm: it
+        # names these three, so a misconfigured broadcaster id is told apart
+        # from a Helix outage instead of arriving as one generic report. An
+        # error this does not name propagates and the caller says so.
         stream = await get_stream(int(config.setting("twitch_broadcaster_id")))
     except (HelixError, TypeError, ValueError) as e:
         await report(e, "Could not check whether the broadcaster is live at startup")

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -105,10 +105,13 @@ async def resume() -> None:
     difference is the whole reason this is not a second call to began().
     """
     try:
-        # Still guarded now that the caller reports a failed startup arm: it
-        # names these three, so a misconfigured broadcaster id is told apart
-        # from a Helix outage instead of arriving as one generic report. An
-        # error this does not name propagates and the caller says so.
+        # These three are exhaustive, which is what lets the docstring promise
+        # not to raise: config.setting is a dict lookup with a default, int()
+        # fails only as TypeError or ValueError, and helix raises HelixError
+        # and nothing else by its own stated contract. Named rather than a
+        # bare except so a broadcaster id that is missing or not a number
+        # stays distinguishable from Twitch being unreachable, rather than
+        # reaching the startup reporter as one undifferentiated failure.
         stream = await get_stream(int(config.setting("twitch_broadcaster_id")))
     except (HelixError, TypeError, ValueError) as e:
         await report(e, "Could not check whether the broadcaster is live at startup")


### PR DESCRIPTION
Closes #25.

## The bug

`run_background_tasks` gathered its two startup arms with `return_exceptions=True` and **discarded the result**. That is silence, not tolerance: the gather completes normally, so `background._finished` sees no exception and nothing reaches the admin channel.

One callee knew and defended itself — `stream_session.resume` carried a comment saying the gather *"would swallow it, leaving the session down with nothing said"*. The other did not. `live_alert.restore_all` opens with an unguarded `await repository.list_live_alerts()`, so **an unreachable database at boot left every stored live alert without an updater for the life of the process, and nothing anywhere said so.**

Nothing else would have caught it either: with no updater started, there is no cycle to exhaust `_MAX_INCONCLUSIVE_CYCLES` and report giving up. That is what made this the one genuinely silent failure left in the startup path.

## The fix

The results are read, and a failed arm becomes a **report** naming *what was lost* rather than the function that lost it — that is what the admin channel needs to act on. `main()` already reads its cog-loading results this way, twenty lines from here.

The two wrappers that existed only to hold a deferred import are gone; the import moved into the caller, still deferred, because both arms reach `services.send`, which imports this package for `bot`.

`resume` keeps its own guard. It names `HelixError`, `TypeError` and `ValueError`, so a misconfigured broadcaster id is still told apart from a Helix outage rather than arriving as one generic report — its comment now says *that*, instead of defending against a caller that no longer eats exceptions. Anything it does not name propagates, and the caller reports it.

## Verification

A throwaway harness that makes each arm raise:

- one failing arm produces exactly one report naming it, **and does not stop the other running**
- both failing produces two reports, neither lost
- the happy path stays silent

The three existing harnesses (session lifecycle, alert-wake independence, composite authorization) stay green. The four checks are clean in order.

**There is no test suite, so this is not tested** — it has not run against a real boot with the database down.

## Gate

WARN, non-blocking, with two findings against `services/twitch/stream_session.py` — a file this PR only edits a comment in. Both verified false and reported as such, **scoped to file and line**:

- the broadcaster id at `:137` is already proven equal to the configured one by the `is_main_broadcaster` guard three lines above, so it is a configuration value by that point, not caller input;
- a delayed ad warning cannot reach a replacement stream, because `_start` and `_end` both cancel it — confirmed by running it (`cancelled -> True`, slot cleared to `None`).

## Also here

`b306d9d` bumps the uv base image `0.12.12 → 0.12.13`, committed separately ahead of the fix so a base-image change and a behaviour change stay independently bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface named failures from concurrent startup background tasks so missing live-alert or stream-session functionality is actionable.

Bug Fixes:
- Report which startup background task failed instead of silently swallowing startup exceptions, including distinct failures for live-alert restoration and stream-session resumption.
- Preserve differentiated reporting for stream-session configuration errors and Twitch API failures.

Enhancements:
- Run startup background tasks concurrently while continuing to report all failed arms without preventing the other task from running.

Build:
- Update the uv Python base image from 0.12.12 to 0.12.13.