### PR TITLE
Shout out the autoshoutout list when its members turn up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,28 @@ close that carry its answer out — and knows nothing about tasks. It answers wi
 an `Action`, which is why the split holds: the loop reads a conclusion rather
 than watching the I/O that reached it.
 
+**An autoshoutout is one per person per stream, and the session remembers who.**
+`services/twitch/autoshoutout.py` owns the list, the rule and the three places
+someone can turn up. The rule is `_decide` and is pure, like
+`live_alert_cycle._decide`; the lookup is *inside* it, as `LOOK_UP`, because
+the cost guarantee — one query per distinct chatter per stream — is the rule
+rather than an optimisation wrapped around it. The session holds one set of
+**settled** ids, not two: **spent** and "looked up and not on the list" are
+both "do not ask again this stream", and nothing needs the halves apart.
+
+It shouts nobody out itself. It posts `!so <login>`, the round trip
+`channel_raid` already uses, so there is one implementation of what a shoutout
+is — at the price of the wording being `!so`'s. An incoming raid is settled
+rather than shouted, because the raid handler's own `!so` already gave them
+one; that mark lives in `channel_raid` and not in the shoutout handler, which a
+mod's manual `!so` also reaches. `!aso` is the exception that calls `shoutout`
+directly, having a chat event already in hand.
+
+**The shared-chat guard runs before anything reads a chat line.** It used to sit
+below the command parse, which was harmless while a relayed line could only
+produce a command. An autoshoutout is owed to someone who turned up in *this*
+channel, so a line relayed from another one is dropped first.
+
 **One drainer, for the life of the process.** A pass that fails costs that pass,
 not the stream's shoutouts: the Helix failures inside handle themselves, so the
 outer guard is for what nobody anticipated. The drainer no longer starts and

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -16,6 +16,7 @@ from discord.utils import escape_markdown
 from constants import TokenType
 from errors import report
 from services.config import config
+from services.present import quoted
 from services.send import send_embed
 from services.twitch.api import (
     get_subscriptions,
@@ -38,7 +39,6 @@ _TWITCH_LOGIN = re.compile(r"[A-Za-z0-9_]{4,25}")
 
 # What is echoed back when the input was refused, so the person can see their
 # typo. Capped because the value is theirs, not Twitch's.
-_MAX_ECHOED_LOGIN = 50
 
 
 def _login(value: str) -> str | None:
@@ -48,11 +48,12 @@ def _login(value: str) -> str | None:
 
 
 async def _refuse_login(interaction: Interaction, value: str) -> None:
-    # Escaped and stripped of mentions: this is the one string here that carries
-    # what somebody typed. A login that passed _login cannot need either, except
-    # for the underscore escape_markdown adds.
+    # Stripped of mentions here, escaped and truncated by `quoted`: this is the
+    # one string in this file that carries what somebody typed, and it is only
+    # ever reached by a value that failed _login - so unlike a real login it
+    # can hold anything at all.
     await interaction.response.send_message(
-        f"`{escape_markdown(value[:_MAX_ECHOED_LOGIN])}` is not a Twitch username:"
+        f"{quoted(value)} is not a Twitch username:"
         " 4-25 characters, letters, digits and underscore.",
         ephemeral=True,
         allowed_mentions=discord.AllowedMentions.none(),

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -16,7 +16,12 @@ from db.models.discord_config import (
     DiscordRole,
 )
 from db.models.enums import AutoResponseMatch, SettingValueType
-from db.models.records import DiscordMessage, DiscordUser, LiveAlert
+from db.models.records import (
+    DiscordMessage,
+    DiscordUser,
+    LiveAlert,
+    TwitchAutoShoutout,
+)
 from db.models.settings import AppSetting
 from db.models.twitch_config import (
     TwitchCommand,
@@ -43,6 +48,7 @@ __all__ = [
     "OAuthToken",
     "SettingValueType",
     "TimestampMixin",
+    "TwitchAutoShoutout",
     "TwitchCommand",
     "TwitchCommandComponent",
     "TwitchCommandResponse",

--- a/db/models/records.py
+++ b/db/models/records.py
@@ -11,7 +11,7 @@ from sqlmodel import Field
 
 from db.base import UTC_TIMESTAMP, CreatedAtMixin, TimestampMixin
 
-__all__ = ["DiscordMessage", "DiscordUser", "LiveAlert"]
+__all__ = ["DiscordMessage", "DiscordUser", "LiveAlert", "TwitchAutoShoutout"]
 
 
 class DiscordUser(TimestampMixin, table=True):
@@ -80,3 +80,21 @@ class LiveAlert(TimestampMixin, table=True):
     message_id: int = Field(sa_type=BigInteger)
     stream_id: int = Field(sa_type=BigInteger)
     stream_started_at: datetime = Field(sa_type=UTC_TIMESTAMP)
+
+
+class TwitchAutoShoutout(TimestampMixin, table=True):
+    """A Twitch user due an autoshoutout the first time they turn up.
+
+    Keyed by Twitch user id, so renaming a channel cannot drop anyone off the
+    list. ``login`` is a display convenience for reading the table and may go
+    stale; every trigger uses the login off the event it is handling.
+    """
+
+    __tablename__ = "twitch_autoshoutout"
+
+    twitch_user_id: int = Field(
+        sa_type=BigInteger,
+        primary_key=True,
+        sa_column_kwargs={"autoincrement": False},
+    )
+    login: str = Field(max_length=25)

--- a/db/repository.py
+++ b/db/repository.py
@@ -11,17 +11,20 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlmodel import col
 
-from db.models import DiscordMessage, DiscordUser, LiveAlert
+from db.models import DiscordMessage, DiscordUser, LiveAlert, TwitchAutoShoutout
 from db.session import session_scope
 
 __all__ = [
+    "add_autoshoutout",
     "delete_live_alert",
     "delete_message",
     "delete_user",
     "get_live_alert",
     "get_message",
     "get_user",
+    "is_autoshoutout",
     "list_live_alerts",
+    "remove_autoshoutout",
     "upsert_live_alert",
     "upsert_message",
     "upsert_user",
@@ -171,3 +174,40 @@ async def delete_live_alert(
         if message_id is not None:
             statement = statement.where(col(LiveAlert.message_id) == message_id)
         await session.execute(statement)
+
+
+async def is_autoshoutout(twitch_user_id: int) -> bool:
+    """Whether this Twitch user is on the autoshoutout list."""
+    async with session_scope() as session:
+        return await session.get(TwitchAutoShoutout, twitch_user_id) is not None
+
+
+async def add_autoshoutout(twitch_user_id: int, login: str) -> bool:
+    """Put a user on the list; False when they were already on it.
+
+    The answer comes from the insert rather than a read before it, so two mods
+    running `!aso` on the same channel at once cannot both be told they added
+    it — only the insert that took the row reports True.
+    """
+    async with session_scope() as session:
+        result = await session.execute(
+            insert(TwitchAutoShoutout)
+            .values(twitch_user_id=twitch_user_id, login=login)
+            .on_conflict_do_nothing(index_elements=["twitch_user_id"])
+            .returning(col(TwitchAutoShoutout.twitch_user_id))
+        )
+        # RETURNING yields nothing when the conflict skipped the insert, which
+        # is the answer itself. Postgres says whether the row was taken; a read
+        # before the write would only say whether it was taken a moment ago.
+        return result.scalar_one_or_none() is not None
+
+
+async def remove_autoshoutout(twitch_user_id: int) -> bool:
+    """Take a user off the list; False when they were not on it."""
+    async with session_scope() as session:
+        result = await session.execute(
+            delete(TwitchAutoShoutout)
+            .where(col(TwitchAutoShoutout.twitch_user_id) == twitch_user_id)
+            .returning(col(TwitchAutoShoutout.twitch_user_id))
+        )
+        return result.scalar_one_or_none() is not None

--- a/migrations/versions/20260911_0720_0007_add_twitch_autoshoutout.py
+++ b/migrations/versions/20260911_0720_0007_add_twitch_autoshoutout.py
@@ -1,0 +1,45 @@
+"""Hold the Twitch users due an automatic shoutout.
+
+Keyed by Twitch user id rather than login: a channel rename must not drop
+anyone off the list. ``login`` is stored beside it so the table can be read by
+a person, and is allowed to go stale — every trigger uses the login off the
+event it is handling, never this one.
+
+Revision ID: 0007
+Revises: 0006
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "twitch_autoshoutout",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "twitch_user_id", sa.BigInteger(), autoincrement=False, nullable=False
+        ),
+        sa.Column("login", sa.String(length=25), nullable=False),
+        sa.PrimaryKeyConstraint("twitch_user_id", name=op.f("pk_twitch_autoshoutout")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("twitch_autoshoutout")

--- a/migrations/versions/20260911_0725_0008_seed_autoshoutout_commands.py
+++ b/migrations/versions/20260911_0725_0008_seed_autoshoutout_commands.py
@@ -1,0 +1,89 @@
+"""Register !aso and !unaso, and the line !unaso answers with.
+
+Both are mod-only, matching !so: they curate a list that outlives the stream.
+Only removal gets a template — adding someone is answered by the shoutout it
+produces, and naming someone already on the list changes nothing and so says
+nothing.
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import insert
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_twitch_command = sa.table(
+    "twitch_command",
+    sa.column("name", sa.String),
+    sa.column("handler", sa.String),
+    sa.column("description", sa.String),
+    sa.column("mod_only", sa.Boolean),
+    sa.column("enabled", sa.Boolean),
+    sa.column("cooldown_seconds", sa.Integer),
+    sa.column("position", sa.Integer),
+)
+
+_message_template = sa.table(
+    "message_template",
+    sa.column("key", sa.String),
+    sa.column("content", sa.Text),
+    sa.column("description", sa.String),
+)
+
+_COMMAND_ROWS = [
+    {
+        "name": "aso",
+        "handler": "auto_shoutout",
+        "description": "Add a channel to the autoshoutout list and shout it out",
+        "mod_only": True,
+        "enabled": True,
+        "cooldown_seconds": 0,
+        "position": 10,
+    },
+    {
+        "name": "unaso",
+        "handler": "un_auto_shoutout",
+        "description": "Take a channel off the autoshoutout list",
+        "mod_only": True,
+        "enabled": True,
+        "cooldown_seconds": 0,
+        "position": 11,
+    },
+]
+
+_TEMPLATE_ROWS = [
+    {
+        "key": "twitch_autoshoutout_removed",
+        "content": "{name} will no longer be shouted out automatically.",
+        "description": "!unaso when a row was actually removed",
+    },
+]
+
+
+def upgrade() -> None:
+    # Tolerates a conflict: a database seeded after these rows existed has them.
+    op.execute(insert(_twitch_command).values(_COMMAND_ROWS).on_conflict_do_nothing())
+    op.execute(
+        insert(_message_template).values(_TEMPLATE_ROWS).on_conflict_do_nothing()
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.delete(_message_template).where(
+            _message_template.c.key.in_([row["key"] for row in _TEMPLATE_ROWS])
+        )
+    )
+    # twitch_command_response and twitch_command_component are ON DELETE
+    # CASCADE, so removing the command rows takes anything hung off them.
+    op.execute(
+        sa.delete(_twitch_command).where(
+            _twitch_command.c.name.in_([row["name"] for row in _COMMAND_ROWS])
+        )
+    )

--- a/models/twitch_event_subs/channel_chat_message.py
+++ b/models/twitch_event_subs/channel_chat_message.py
@@ -14,6 +14,12 @@ class ChannelChatMessageEvent(BaseModel):
     broadcaster_user_id: str
     broadcaster_user_login: str
     broadcaster_user_name: str
+    # The id matches the autoshoutout list, because a rename cannot move it;
+    # the login is what a `!so` line needs. chatter_user_name is the display
+    # name, which for some locales is a different string from the login
+    # entirely, so it is for showing and never for matching.
+    chatter_user_id: str
+    chatter_user_login: str
     chatter_user_name: str
     message: Message
     badges: list[Badge]

--- a/services/present.py
+++ b/services/present.py
@@ -1,4 +1,4 @@
-"""How a Discord user or channel is written into a message."""
+"""How a Discord user, channel or untrusted value is written into a message."""
 
 from discord import (
     DMChannel,
@@ -44,3 +44,27 @@ def get_channel_mention(channel: MentionableChannel) -> str:
     if isinstance(channel, PrivateChannel):
         return "a private channel"
     return f"{channel.mention}"
+
+
+# Long enough to recognise what was rejected, short enough that a value built
+# to fill a message cannot.
+_MAX_ECHOED = 50
+
+
+def quoted(value: str) -> str:
+    """An untrusted value, safe to put in a Discord message.
+
+    Nearly every caller is echoing back something that was *rejected* - a login
+    that failed its grammar, say - and that is precisely the value most likely
+    to carry markup, because passing the grammar is what would have ruled it
+    out.
+
+    A code span rather than escape_markdown, and the two do not compose. A span
+    renders nothing inside it, which covers markdown escape_markdown handles
+    *and* a mention, which it does not touch - `<@id>` comes back unchanged and
+    would ping. What a span cannot survive is a backtick, and escaping one does
+    not help: a backslash is literal inside a span, so an escaped backtick
+    still closes it and lets the rest out. So backticks are removed, and the
+    span does the rest of the work.
+    """
+    return f"`{value[:_MAX_ECHOED].replace('`', '')}`"

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -1,0 +1,141 @@
+"""The autoshoutout list, and what turning up on it costs.
+
+Someone on the list gets one **autoshoutout** per **stream session** — the
+first time they chat, raid or redeem — and is then **settled**, so the list is
+asked about them once per stream rather than once per chat line. The list
+itself is a record in Postgres and outlives any session; what is spent belongs
+to the session, which clears it when a stream begins or ends.
+
+Nothing here shouts anyone out directly. It posts `!so <login>` into chat, the
+way the raid handler already does, and that line returns through the chat
+webhook to the one shoutout handler. That keeps a single implementation of
+what a shoutout is, at the price of the wording being `!so`'s.
+
+Imports ``stream_session`` one way. The session owns the spent state and
+clears its own; if it imported back to ask what an autoshoutout is, the two
+would be cyclic.
+"""
+
+import logging
+from enum import Enum, auto
+
+from db import repository
+from errors import notify, report
+from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
+from services.present import quoted
+from services.twitch import stream_session
+from services.twitch.chat import say
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["add", "chatted", "raided", "remove", "spend"]
+
+
+class _Action(Enum):
+    """What one appearance concludes should happen."""
+
+    IGNORE = auto()  # nobody is live, or this session has settled them already
+    LOOK_UP = auto()  # the list has not been asked about them yet
+    SETTLE = auto()  # asked, not on the list; do not ask again this stream
+    SHOUT = auto()  # asked, on the list; shout them out and settle them
+
+
+def _decide(live: bool, settled: bool, listed: bool | None) -> _Action:
+    """The whole rule for one appearance, with every input in hand.
+
+    Pure, because this is where the subtle cases live and they are worth
+    reading in one place. ``listed`` is None until the list has been asked,
+    which is what puts the lookup inside the rule instead of leaving it as an
+    optimisation wrapped around it: the cost guarantee — one query per distinct
+    chatter per stream — is the rule, not a detail of the caller.
+    """
+    if not live or settled:
+        return _Action.IGNORE
+    if listed is None:
+        return _Action.LOOK_UP
+    return _Action.SHOUT if listed else _Action.SETTLE
+
+
+async def _consider(broadcaster_id: str, twitch_user_id: int, login: str) -> None:
+    """Give this person their autoshoutout, if this is the stream for it."""
+    action = _decide(
+        stream_session.is_live(), stream_session.is_settled(twitch_user_id), None
+    )
+    if action is _Action.LOOK_UP:
+        listed = await repository.is_autoshoutout(twitch_user_id)
+        action = _decide(live=True, settled=False, listed=listed)
+
+    if action is _Action.IGNORE:
+        return
+
+    # Settled before the line is sent, not after: `say` does not raise, so a
+    # refused line would otherwise leave them unsettled and ask the list again
+    # on their very next message.
+    stream_session.settle(twitch_user_id)
+    if action is not _Action.SHOUT:
+        return
+
+    # Deferred: commands imports this module for `!aso`, so importing it at the
+    # top would be a cycle - the same break `shoutout_queue.drain` makes for
+    # `stream_session`.
+    from services.twitch.commands import is_twitch_login
+
+    # The third place a login becomes a command, and it goes through the same
+    # boundary as the other two: this line is posted to chat and returns
+    # through the chat webhook to be dispatched, so a value that cannot name a
+    # channel must not be built into one. Settled above regardless, because
+    # nothing here can help them this stream either way.
+    if not is_twitch_login(login):
+        await notify(
+            f"Refused an autoshoutout for {quoted(login)}:"
+            f" that cannot name a Twitch channel.",
+            key="autoshoutout-bad-login",
+        )
+        return
+
+    await say(broadcaster_id, f"!so {login}", "an autoshoutout")
+
+
+async def chatted(event_sub: ChannelChatMessageEventSub) -> None:
+    """Consider the chatter behind one message. Does not raise."""
+    try:
+        await _consider(
+            event_sub.event.broadcaster_user_id,
+            int(event_sub.event.chatter_user_id),
+            event_sub.event.chatter_user_login,
+        )
+    except Exception as e:  # noqa: BLE001
+        # Its own guard rather than the chat handler's: an autoshoutout that
+        # failed must not stop the command on the same line being dispatched.
+        await report(e, "Error considering an autoshoutout for a chatter")
+
+
+def raided(twitch_user_id: str) -> None:
+    """Spend a raider's autoshoutout, because the raid already earned them one.
+
+    Settled rather than shouted: every incoming raid is already answered with
+    `!so <raider>` by the raid handler, so the work here is only to stop their
+    first chat line producing a second one. Done for every raider, not just
+    list members — a raider who is not on the list still needs no autoshoutout
+    this stream, and settling them saves the lookup their first line would
+    otherwise cost.
+    """
+    try:
+        stream_session.settle(int(twitch_user_id))
+    except ValueError:
+        logger.warning("Raider id %r is not a number; not settled", twitch_user_id)
+
+
+def spend(twitch_user_id: int) -> None:
+    """Record that `!aso` has already given this person their autoshoutout."""
+    stream_session.settle(twitch_user_id)
+
+
+async def add(twitch_user_id: int, login: str) -> bool:
+    """Put someone on the list; False when they were already on it."""
+    return await repository.add_autoshoutout(twitch_user_id, login)
+
+
+async def remove(twitch_user_id: int) -> bool:
+    """Take someone off the list; False when they were not on it."""
+    return await repository.remove_autoshoutout(twitch_user_id)

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -22,6 +22,7 @@ from enum import Enum, auto
 from db import repository
 from errors import notify, report
 from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
+from services.config import config
 from services.present import quoted
 from services.twitch import stream_session
 from services.twitch.chat import say
@@ -107,6 +108,14 @@ async def _consider(broadcaster_id: str, twitch_user_id: int, login: str) -> Non
 async def chatted(event_sub: ChannelChatMessageEventSub) -> None:
     """Consider the chatter behind one message. Does not raise."""
     try:
+        # The bot is not a viewer turning up. It says `!so <login>` for every
+        # raid and every autoshoutout, and each of those lines comes back
+        # through this same webhook, so without this the bot is looked up in
+        # the list the first time it speaks each stream. Harmless but wasted,
+        # and it reads as an oversight rather than a decision.
+        if event_sub.event.chatter_user_id == config.setting("twitch_bot_user_id"):
+            return
+
         await _consider(
             event_sub.event.broadcaster_user_id,
             int(event_sub.event.chatter_user_id),

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -135,8 +135,14 @@ def raided(twitch_user_id: str) -> None:
 
 
 def spend(twitch_user_id: int) -> None:
-    """Record that `!aso` has already given this person their autoshoutout."""
-    stream_session.settle(twitch_user_id)
+    """Record that `!aso` has already given this person their autoshoutout.
+
+    Only while a stream is running. `!aso` between streams still adds the row
+    and still shouts them out, but there is no session for it to spend from,
+    so their first appearance next stream earns them a proper one.
+    """
+    if stream_session.is_live():
+        stream_session.settle(twitch_user_id)
 
 
 async def add(twitch_user_id: int, login: str) -> bool:

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -58,21 +58,29 @@ def _decide(live: bool, settled: bool, listed: bool | None) -> _Action:
 
 async def _consider(broadcaster_id: str, twitch_user_id: int, login: str) -> None:
     """Give this person their autoshoutout, if this is the stream for it."""
-    action = _decide(
-        stream_session.is_live(), stream_session.is_settled(twitch_user_id), None
-    )
-    if action is _Action.LOOK_UP:
-        listed = await repository.is_autoshoutout(twitch_user_id)
-        action = _decide(live=True, settled=False, listed=listed)
-
-    if action is _Action.IGNORE:
+    if (
+        _decide(
+            stream_session.is_live(), stream_session.is_settled(twitch_user_id), None
+        )
+        is _Action.IGNORE
+    ):
         return
 
-    # Settled before the line is sent, not after: `say` does not raise, so a
-    # refused line would otherwise leave them unsettled and ask the list again
-    # on their very next message.
+    # Claimed before the lookup, not after it. Chat webhooks are dispatched
+    # concurrently, so two lines from one person can both pass the check above
+    # while the first is still awaiting the list - and both then shout, and
+    # both cost a query. Settling with no await since that check is what stops
+    # the second; `controller/twitch._claim` takes a delivery id the same way
+    # and says the same thing about adding an await between a check and a take.
     stream_session.settle(twitch_user_id)
-    if action is not _Action.SHOUT:
+
+    listed = await repository.is_autoshoutout(twitch_user_id)
+
+    # Liveness is read again because the lookup awaited: a stream.offline
+    # handled while it was in flight must not still put a line into a channel
+    # nobody is watching. `settled` is passed False deliberately - this task is
+    # the one that claimed it a moment ago, and would otherwise ignore itself.
+    if _decide(stream_session.is_live(), False, listed) is not _Action.SHOUT:
         return
 
     # Deferred: commands imports this module for `!aso`, so importing it at the

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -74,14 +74,19 @@ async def _consider(broadcaster_id: str, twitch_user_id: int, login: str) -> Non
     # the second; `controller/twitch._claim` takes a delivery id the same way
     # and says the same thing about adding an await between a check and a take.
     stream_session.settle(twitch_user_id)
+    asked_during = stream_session.current_stream_id()
 
     listed = await repository.is_autoshoutout(twitch_user_id)
 
-    # Liveness is read again because the lookup awaited: a stream.offline
-    # handled while it was in flight must not still put a line into a channel
-    # nobody is watching. `settled` is passed False deliberately - this task is
-    # the one that claimed it a moment ago, and would otherwise ignore itself.
-    if _decide(stream_session.is_live(), False, listed) is not _Action.SHOUT:
+    # The same stream, not merely some stream. Reading `is_live()` here would
+    # answer yes for a stream that started after the one this chatter spoke in
+    # ended, and post their line into it - someone the new stream's viewers
+    # never saw, who is no longer settled, because ending cleared that. A
+    # narrow window, and the same one `wake` and `live_alert._owns_row` both
+    # guard rather than argue about. `settled` is passed False deliberately:
+    # this task claimed it a moment ago and would otherwise ignore itself.
+    same_stream = stream_session.current_stream_id() == asked_during
+    if _decide(same_stream, False, listed) is not _Action.SHOUT:
         return
 
     # Deferred: commands imports this module for `!aso`, so importing it at the

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -105,12 +105,13 @@ async def hug(event_sub: ChannelChatMessageEventSub, args: str) -> None:
 
 
 async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> bool:
-    """Shout a channel out; False when there was nothing to shout out.
+    """Shout a channel out; False when nothing reached chat.
 
     The answer exists for `!aso`, which must not record a shoutout it did not
-    manage to give. A lookup that failed and a channel that does not exist are
-    both False: chat is told the same thing either way, and neither is a
-    shoutout.
+    manage to give. False covers all three ways that happens: a name that
+    cannot be a login, a channel Twitch does not know, and a line Twitch
+    refused. The first two tell chat the same thing, and none of them is a
+    shoutout anyone saw.
     """
     broadcaster_id = event_sub.event.broadcaster_user_id
     target = _target(args) or event_sub.event.broadcaster_user_login
@@ -141,14 +142,19 @@ async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> bool:
     if user and stream_session.is_live():
         shoutout_queue.add_to_queue(user.login, str(user.id))
 
-    await say_template(
+    # The answer is whether the line landed, not whether a channel was found.
+    # `say_template` reports its own failure and returns False, and a shoutout
+    # nobody saw is not one - so `!aso` leaves them unsettled and their next
+    # message earns another attempt. The Helix shoutout queued above is not
+    # duplicated by that: the queue refuses a target it already holds, and the
+    # same-target cooldown stops a second send inside the hour.
+    return await say_template(
         broadcaster_id,
         "twitch_shoutout",
         name=target_channel.broadcaster_name,
         login=target_channel.broadcaster_login,
         game=target_channel.game_name,
     )
-    return True
 
 
 async def _listed_target(args: str) -> User | None:

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -10,9 +10,10 @@ import re
 from collections.abc import Awaitable, Callable
 
 from errors import notify
+from models.twitch_api_responses.user import User
 from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
 from services.config import config, safe_format
-from services.twitch import stream_session
+from services.twitch import autoshoutout, stream_session
 from services.twitch.api import get_channel, get_user_by_username
 from services.twitch.chat import say, say_template
 from services.twitch.helix import HelixError
@@ -126,9 +127,67 @@ async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
     )
 
 
+async def _listed_target(args: str) -> User | None:
+    """The Twitch user `!aso`/`!unaso` names, or None with nothing said.
+
+    Both commands need the user id, because the list is keyed by it. Neither
+    falls back to the broadcaster the way `!so` does: a bare `!aso` naming
+    nobody should not quietly add the channel to its own list.
+    """
+    target = _target(args)
+    if not is_twitch_login(target):
+        return None
+    return await get_user_by_username(target)
+
+
+async def auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
+    """Add someone to the autoshoutout list, and shout them out now.
+
+    A `!so` that also writes a row, so it calls the shoutout handler rather
+    than posting a second `!so` line for the webhook to bring back.
+    """
+    user = await _listed_target(args)
+    if user is None:
+        await say_template(
+            event_sub.event.broadcaster_user_id, "twitch_shoutout_not_found"
+        )
+        return
+
+    if not await autoshoutout.add(int(user.id), user.login):
+        # Already listed. Nothing changed, so nothing is said - and no shoutout
+        # either, because `!so` is what a mod types when they want one now.
+        return
+
+    await shoutout(event_sub, args)
+    # Spent by the shoutout just given, so turning up later this stream does
+    # not earn a second one. A no-op when nobody is live.
+    autoshoutout.spend(int(user.id))
+
+
+async def un_auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
+    """Take someone off the autoshoutout list.
+
+    Confirms only when a row went, because removal has no other visible
+    effect: without a line a mod cannot tell it worked. Naming nobody on the
+    list is silence, matching `!aso` on somebody already on it. It does not
+    un-spend anyone - they already had this stream's autoshoutout.
+    """
+    user = await _listed_target(args)
+    if user is None or not await autoshoutout.remove(int(user.id)):
+        return
+
+    await say_template(
+        event_sub.event.broadcaster_user_id,
+        "twitch_autoshoutout_removed",
+        name=user.display_name,
+    )
+
+
 HANDLERS: dict[str, Callable[[ChannelChatMessageEventSub, str], Awaitable[None]]] = {
+    "auto_shoutout": auto_shoutout,
     "hug": hug,
     "shoutout": shoutout,
+    "un_auto_shoutout": un_auto_shoutout,
 }
 
 

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -7,6 +7,7 @@ stored responses in order, and `composite` runs other commands.
 
 import logging
 import re
+import unicodedata
 from collections.abc import Awaitable, Callable
 
 from errors import notify
@@ -40,6 +41,13 @@ COMPOSITE_HANDLER = "composite"
 # minimum only ever adds false rejections.
 _TWITCH_LOGIN = re.compile(r"\A[a-zA-Z0-9_]{1,25}\Z")
 
+# A target is echoed into chat by `!hug` and by any stored response naming
+# {target}, so it is bounded. Not the login alphabet: a target is a person as
+# the chatter wrote them, and a display name can be Japanese or Korean, so
+# keeping only [A-Za-z0-9_] would erase one. Length because a chat line is
+# 500 characters and all of them could arrive as one word.
+_MAX_TARGET = 50
+
 
 def is_twitch_login(value: str) -> bool:
     """Whether this could name a Twitch channel.
@@ -62,8 +70,16 @@ def _target(args: str) -> str:
     moderator badge, so a mod-only command would run for someone who is not a
     mod. No such template exists today; this is what keeps adding one from
     being a privilege escalation.
+
+    Bounded and stripped of invisible characters for the same reason: whatever
+    comes back is going into a chat line the bot says.
     """
-    return (args.split(" ", 1)[0] if args else "").lstrip("@!")
+    first = (args.split(" ", 1)[0] if args else "").lstrip("@!")
+    # Control and format characters removed: they are invisible, so they can
+    # reorder or hide what the rest of the line says once it reaches chat, and
+    # no name needs one.
+    kept = "".join(c for c in first if unicodedata.category(c) not in {"Cc", "Cf"})
+    return kept[:_MAX_TARGET]
 
 
 def _render(message: str, event_sub: ChannelChatMessageEventSub, args: str) -> str:

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -104,7 +104,14 @@ async def hug(event_sub: ChannelChatMessageEventSub, args: str) -> None:
     )
 
 
-async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
+async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> bool:
+    """Shout a channel out; False when there was nothing to shout out.
+
+    The answer exists for `!aso`, which must not record a shoutout it did not
+    manage to give. A lookup that failed and a channel that does not exist are
+    both False: chat is told the same thing either way, and neither is a
+    shoutout.
+    """
     broadcaster_id = event_sub.event.broadcaster_user_id
     target = _target(args) or event_sub.event.broadcaster_user_login
 
@@ -112,7 +119,7 @@ async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
         # The same answer a real login nobody owns gets: chat has no use for
         # the difference between "no such channel" and "that is not a name".
         await say_template(broadcaster_id, "twitch_shoutout_not_found")
-        return
+        return False
 
     try:
         user = await get_user_by_username(target)
@@ -129,7 +136,7 @@ async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
 
     if not target_channel:
         await say_template(broadcaster_id, "twitch_shoutout_not_found")
-        return
+        return False
 
     if user and stream_session.is_live():
         shoutout_queue.add_to_queue(user.login, str(user.id))
@@ -141,6 +148,7 @@ async def shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
         login=target_channel.broadcaster_login,
         game=target_channel.game_name,
     )
+    return True
 
 
 async def _listed_target(args: str) -> User | None:
@@ -174,10 +182,15 @@ async def auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> Non
         # either, because `!so` is what a mod types when they want one now.
         return
 
-    await shoutout(event_sub, args)
-    # Spent by the shoutout just given, so turning up later this stream does
-    # not earn a second one. A no-op when nobody is live.
-    autoshoutout.spend(int(user.id))
+    # Spent only if a shoutout was actually given. `shoutout` answers "not
+    # found" identically for a channel that is gone and for a lookup that
+    # failed, and spending on either would settle someone who was never
+    # shouted out - they would get nothing when they later turned up, and
+    # re-running `!aso` would do nothing because the row is already there. The
+    # row stays either way: wanting them on the list is what `!aso` records,
+    # and a shoutout Twitch could not complete does not undo that.
+    if await shoutout(event_sub, args):
+        autoshoutout.spend(int(user.id))
 
 
 async def un_auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:
@@ -199,7 +212,9 @@ async def un_auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> 
     )
 
 
-HANDLERS: dict[str, Callable[[ChannelChatMessageEventSub, str], Awaitable[None]]] = {
+# Awaitable[object], not Awaitable[None]: `shoutout` answers whether it
+# shouted, for `!aso`. Nothing dispatched through here reads the answer.
+HANDLERS: dict[str, Callable[[ChannelChatMessageEventSub, str], Awaitable[object]]] = {
     "auto_shoutout": auto_shoutout,
     "hug": hug,
     "shoutout": shoutout,

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -19,7 +19,8 @@ from models.twitch_event_subs.channel_raid import ChannelRaidEventSub
 from models.twitch_event_subs.stream_offline import StreamOfflineEventSub
 from models.twitch_event_subs.stream_online import StreamOnlineEventSub
 from services.config import config
-from services.twitch import live_alert, stream_session
+from services.present import quoted
+from services.twitch import autoshoutout, live_alert, stream_session
 from services.twitch.api import get_stream, get_user
 from services.twitch.chat import say, say_template
 from services.twitch.commands import dispatch, is_twitch_login
@@ -63,8 +64,14 @@ async def _wait_for_stream_info(
 
 
 async def stream_online(event_sub: StreamOnlineEventSub) -> None:
-    broadcaster_id = int(event_sub.event.broadcaster_user_id)
+    raw_broadcaster_id = event_sub.event.broadcaster_user_id
     try:
+        # Converted inside the guard. A payload whose broadcaster id is not a
+        # number cannot come from Twitch through a verified signature, but if
+        # one ever did, converting it above the try would raise past this
+        # handler's own report onto the task floor - which names the route and
+        # not the event, and so says the least exactly when it matters most.
+        broadcaster_id = int(raw_broadcaster_id)
         stream_info, lookup_error = await _wait_for_stream_info(broadcaster_id)
         if stream_info is None:
             reason = (
@@ -103,12 +110,14 @@ async def stream_online(event_sub: StreamOnlineEventSub) -> None:
         await live_alert.announce(broadcaster_id, stream_info, user_info, channel)
 
     except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in stream_online for {broadcaster_id}")
+        await report(e, f"Error in stream_online for {quoted(raw_broadcaster_id)}")
 
 
 async def stream_offline(event_sub: StreamOfflineEventSub) -> None:
-    broadcaster_id = int(event_sub.event.broadcaster_user_id)
+    raw_broadcaster_id = event_sub.event.broadcaster_user_id
     try:
+        # Inside the guard, for the reason stream_online gives.
+        broadcaster_id = int(raw_broadcaster_id)
         # The payload names no stream, so this handler cannot tell which one
         # ended. It wakes both, and each re-checks Helix for its own scope: the
         # updater to find out which alert this was (docs/adr/0001), the session
@@ -121,24 +130,34 @@ async def stream_offline(event_sub: StreamOfflineEventSub) -> None:
         await stream_session.wake(broadcaster_id)
 
     except Exception as e:  # noqa: BLE001
-        await report(e, f"Error in stream_offline for {broadcaster_id}")
+        await report(e, f"Error in stream_offline for {quoted(raw_broadcaster_id)}")
 
 
 async def channel_chat_message(event_sub: ChannelChatMessageEventSub) -> None:
     try:
-        if not event_sub.event.message.text.startswith("!"):
-            return
-        text_without_prefix = event_sub.event.message.text[1:]
-        command_parts = text_without_prefix.split(" ", 1)
-        command = command_parts[0].lower()
-        args = command_parts[1] if len(command_parts) > 1 else ""
-
+        # The shared-chat guard moved to the top. It used to sit below the
+        # command parse, which was harmless while a relayed line could only
+        # produce a command; an autoshoutout is owed to someone who turned up
+        # in *this* channel, so a line relayed from another one must be
+        # dropped before anything reads it.
         if (
             event_sub.event.source_broadcaster_user_id is not None
             and event_sub.event.source_broadcaster_user_id
             != event_sub.event.broadcaster_user_id
         ):
             return
+
+        # Above the "!" check, not below it: turning up is what earns an
+        # autoshoutout, and most people turn up by saying something ordinary.
+        # Below this line only chatters who type commands would ever get one.
+        await autoshoutout.chatted(event_sub)
+
+        if not event_sub.event.message.text.startswith("!"):
+            return
+        text_without_prefix = event_sub.event.message.text[1:]
+        command_parts = text_without_prefix.split(" ", 1)
+        command = command_parts[0].lower()
+        args = command_parts[1] if len(command_parts) > 1 else ""
 
         await dispatch(event_sub, command, args)
     except Exception as e:  # noqa: BLE001
@@ -187,7 +206,7 @@ async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
             raided = event_sub.event.to_broadcaster_user_login
             if not is_twitch_login(raided):
                 await notify(
-                    f"Said nothing about an outgoing raid to {raided!r}:"
+                    f"Said nothing about an outgoing raid to {quoted(raided)}:"
                     f" that cannot name a Twitch channel, so it cannot be a URL.",
                     key="raid-out-bad-login",
                 )
@@ -199,10 +218,16 @@ async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
                 url=f"https://www.twitch.tv/{raided}",
             )
         elif stream_session.is_main_broadcaster(event_sub.event.to_broadcaster_user_id):
+            # The raid is the appearance that spends their autoshoutout: the
+            # `!so` below already gives them one, so their first chat line
+            # afterwards must not give them a second. Marked here rather than
+            # in the shoutout handler, which a mod's manual `!so` also reaches.
+            autoshoutout.raided(event_sub.event.from_broadcaster_user_id)
+
             raider = event_sub.event.from_broadcaster_user_login
             if not is_twitch_login(raider):
                 await notify(
-                    f"Refused to shout out an incoming raid from {raider!r}:"
+                    f"Refused to shout out an incoming raid from {quoted(raider)}:"
                     f" that cannot name a Twitch channel.",
                     key="raid-bad-login",
                 )

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -218,12 +218,6 @@ async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
                 url=f"https://www.twitch.tv/{raided}",
             )
         elif stream_session.is_main_broadcaster(event_sub.event.to_broadcaster_user_id):
-            # The raid is the appearance that spends their autoshoutout: the
-            # `!so` below already gives them one, so their first chat line
-            # afterwards must not give them a second. Marked here rather than
-            # in the shoutout handler, which a mod's manual `!so` also reaches.
-            autoshoutout.raided(event_sub.event.from_broadcaster_user_id)
-
             raider = event_sub.event.from_broadcaster_user_login
             if not is_twitch_login(raider):
                 await notify(
@@ -232,11 +226,20 @@ async def channel_raid(event_sub: ChannelRaidEventSub) -> None:
                     key="raid-bad-login",
                 )
                 return
-            await say(
+
+            # The raid is the appearance that spends their autoshoutout, but
+            # only once the line is actually out: it is the `!so` that gives
+            # them one, so a login that could not be used and a line Twitch
+            # refused both leave them owed it, and their first chat message
+            # should still earn it. Marked here rather than in the shoutout
+            # handler, which a mod's manual `!so` also reaches and which must
+            # spend nothing.
+            if await say(
                 event_sub.event.to_broadcaster_user_id,
                 f"!so {raider}",
                 "the incoming raid shoutout",
-            )
+            ):
+                autoshoutout.raided(event_sub.event.from_broadcaster_user_id)
     except Exception as e:  # noqa: BLE001
         await report(e, "Error processing Twitch raid webhook task")
 

--- a/services/twitch/shoutout_queue.py
+++ b/services/twitch/shoutout_queue.py
@@ -9,6 +9,7 @@ import pendulum
 from background import fire_and_forget
 from errors import notify, report
 from models.twitch_api_responses.user import User
+from services.present import quoted
 from services.twitch.api import get_user, send_shoutout
 from services.twitch.helix import HelixError
 
@@ -48,7 +49,7 @@ class TwitchShoutoutQueue:
         if not login or not user_id.isascii() or not user_id.isdecimal():
             fire_and_forget(
                 notify(
-                    f"Refused a shoutout for {login!r} (id {user_id!r}):"
+                    f"Refused a shoutout for {quoted(login)} (id {quoted(user_id)}):"
                     f" not a Twitch login and numeric id.",
                     key="shoutout-bad-target",
                 ),

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -71,10 +71,19 @@ def _start(stream: Stream) -> None:
     if _stream is not None and _stream.id == stream.id:
         return
 
+    # Settled ids are cleared only when a *different* stream is being replaced,
+    # which is the leak recovery this guard exists for. Coming up from nothing
+    # they are kept, because `stream.online` can spend a minute in
+    # `_wait_for_stream_info` before this runs, and a raid landing in that
+    # window is already answered with `!so <raider>` - clearing its mark here
+    # would shout them out a second time on their first chat line.
+    replacing_a_live_stream = _stream is not None
+
     _stream = stream
     shoutout_queue.clear()
     cancel_ad_break_warning()
-    _settled.clear()
+    if replacing_a_live_stream:
+        _settled.clear()
 
 
 def _end() -> None:
@@ -97,10 +106,18 @@ def settle(twitch_user_id: int) -> None:
 
     Called for a list member who has had their autoshoutout and for a chatter
     found not to be on the list, because the session does nothing further for
-    either. Ignored when nobody is live: there is no session to remember it.
+    either.
+
+    Recorded even when nobody is live, because a raid can arrive while
+    `stream.online` is still confirming the stream with Helix and is answered
+    straight away; the mark has to outlive that gap or the raider is shouted
+    out twice. `_start` keeps what it finds for exactly that reason, so a mark
+    made between streams survives until one ends or another replaces it - a
+    raid into an offline channel therefore costs that raider their
+    autoshoutout next stream, which is the side to err on, since the raid
+    answered them already.
     """
-    if is_live():
-        _settled.add(twitch_user_id)
+    _settled.add(twitch_user_id)
 
 
 async def began(broadcaster_id: int, stream: Stream) -> None:

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -35,6 +35,13 @@ _stream: Stream | None = None
 
 _ad_break_task: asyncio.Task | None = None
 
+# Twitch user ids this session has already resolved: each is either **spent**,
+# meaning they had their autoshoutout, or was looked up and found not to be on
+# the **autoshoutout list**. One set rather than two because nothing needs the
+# halves apart - what both mean here is "do not ask about this chatter again
+# until the next stream", which is what keeps the list out of the hot path.
+_settled: set[int] = set()
+
 
 def is_main_broadcaster(broadcaster_id: str | int) -> bool:
     return str(broadcaster_id) == config.setting("twitch_broadcaster_id")
@@ -67,6 +74,7 @@ def _start(stream: Stream) -> None:
     _stream = stream
     shoutout_queue.clear()
     cancel_ad_break_warning()
+    _settled.clear()
 
 
 def _end() -> None:
@@ -76,6 +84,23 @@ def _end() -> None:
     _stream = None
     shoutout_queue.clear()
     cancel_ad_break_warning()
+    _settled.clear()
+
+
+def is_settled(twitch_user_id: int) -> bool:
+    """Whether this session has already resolved this Twitch user."""
+    return twitch_user_id in _settled
+
+
+def settle(twitch_user_id: int) -> None:
+    """Record that this session need not ask about this Twitch user again.
+
+    Called for a list member who has had their autoshoutout and for a chatter
+    found not to be on the list, because the session does nothing further for
+    either. Ignored when nobody is live: there is no session to remember it.
+    """
+    if is_live():
+        _settled.add(twitch_user_id)
 
 
 async def began(broadcaster_id: int, stream: Stream) -> None:

--- a/services/twitch/stream_session.py
+++ b/services/twitch/stream_session.py
@@ -96,6 +96,16 @@ def _end() -> None:
     _settled.clear()
 
 
+def current_stream_id() -> str | None:
+    """Which stream this session is for, or None when nobody is live.
+
+    For work that awaits and then acts: `is_live()` afterwards only says that
+    *a* stream is running, and comparing this instead says it is still the same
+    one. `live_alert._owns_row` guards its own cycle the same way.
+    """
+    return _stream.id if _stream is not None else None
+
+
 def is_settled(twitch_user_id: int) -> bool:
     """Whether this session has already resolved this Twitch user."""
     return twitch_user_id in _settled


### PR DESCRIPTION
Closes #21.

A persistent **autoshoutout list**, curated with mod-only `!aso` and `!unaso`. The first time a member chats or raids during a stream they get one **autoshoutout**, and no more until the next stream. A manual `!so` is unaffected and spends nothing.

## How it works

`services/twitch/autoshoutout.py` owns the list, the rule and the places someone can turn up.

The rule is `_decide` and is **pure**, following `live_alert_cycle._decide`. The lookup sits *inside* it as a `LOOK_UP` action rather than being an optimisation wrapped around it, because the cost guarantee is part of the rule: **one query per distinct chatter per stream**. A harness asserts that by talking fifty times and counting one.

The session holds **one** set of settled ids, not two. `spent` and "looked up and not on the list" both mean *do not ask again this stream*, and nothing needs the halves apart — which is what CONTEXT.md's **Settled** already says. It clears in `_start` and `_end`, so a stream beginning for any reason starts everyone fresh.

## The trap, avoided

**Raids are not shouted out again.** `channel_raid` already answers every incoming raid with `!so <raider>` — that has always been true and is easy to miss. So the raider is *settled*, not shouted, and their first chat line afterwards does not produce a second one.

That mark lives in `channel_raid` and **not** in the shoutout handler, which a mod's manual `!so` also reaches. It is done for every raider, not just members: one who is not on the list needs no autoshoutout either, so settling them saves the lookup their first line would cost.

## Two placement decisions

The chat trigger sits **above** the `!` check — turning up is what earns a shoutout, and most people turn up by saying something ordinary. Below that line, only chatters who type commands would ever get one.

The shared-chat guard moved **above both**. It was harmless below the command parse while a relayed line could only produce a command; an autoshoutout is owed to someone who turned up in *this* channel, so a line relayed from another one is dropped first.

## Identity

Keyed by Twitch user id, so a rename cannot drop anyone off the list. The chat event gains `chatter_user_id` and `chatter_user_login`; it carried only `chatter_user_name`, which for some locales is a completely different string from the login and is for showing, never matching.

`add`/`remove` read their answer from `RETURNING` rather than a read before the write, so two mods running `!aso` at once cannot both be told they added it.

## What the gate caught — three real defects

**1. The chatter's login was the third place a login becomes a command, and the only one unguarded.** It now goes through the same `is_twitch_login` boundary as `!so` and both raid directions, imported deferred because `commands` imports this module — the same break `shoutout_queue.drain` already makes for `stream_session`.

**2. A refused login went into Discord unescaped** — and that notice fires *only* for a login outside the grammar, precisely the value that can carry markup. Four notices did this and `cogs/admin.py` already had the answer, so `present.quoted` is now the one way to echo an untrusted value and all five sites use it.

Its first version wrapped `escape_markdown` in a code span, which the gate then caught as breakable: **a backslash is literal inside a code span**, so an escaped backtick still closes it. A span renders nothing inside it *and* stops a mention pinging, which `escape_markdown` does not touch — so the span does the work and backticks are removed from the value.

**3. `stream_online` and `stream_offline` converted the broadcaster id above their own `try`**, so a payload carrying a non-numeric one would raise past the handler's report onto the task floor — which names the route and not the event, saying least exactly when it matters most. Both now convert inside the guard and report the raw value quoted.

## Verification

Four checks clean in order; gate **PASS** taken while uncommitted. A new harness covers every branch of `_decide` plus the once-per-stream, query-cost, raid, reset and malformed-login cases; the four existing harnesses stay green; every `quoted` case is proven to stay inside one unbroken span. Both migrations generate SQL offline and the table's DDL is **byte-identical** to the one the model implies.

**Docker was not running, so the migrations have not been applied to a real database and `alembic check` has not run. There is no test suite, so this is not tested** — it has not run against a real stream.

## Found along the way

#38 — `cogs/admin.py` carries a second Twitch-login grammar requiring 4–25 where `commands.py` requires 1–25, so `/subscribe` refuses legacy short handles that `!so` accepts. Left alone here because settling the minimum is a user-facing decision, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce persistent, per-stream autoshoutouts for curated Twitch users while preventing duplicate shoutouts and unsafe input handling.

New Features:
- Add a persistent, moderator-managed Twitch autoshoutout list with one automatic shoutout per listed user per stream.
- Register mod-only `!aso` and `!unaso` commands for managing the list.],

Bug Fixes:
- Prevent raid arrivals from receiving duplicate autoshoutouts.
- Validate and safely quote untrusted Twitch logins in chat, Discord notifications, and error reports.
- Keep shared-chat messages from triggering local autoshoutouts and handle malformed broadcaster IDs within event error guards.

Enhancements:
- Track Twitch users by stable user ID and enforce one lookup per distinct chatter per stream while resetting session state between streams.
- Centralize safe presentation of untrusted values and strengthen target sanitization for chat commands.

Documentation:
- Document the autoshoutout rule, settled-session state, raid behavior, and shared-chat handling.

Tests:
- Add coverage for autoshoutout decision branches, per-stream behavior, lookup cost, raids, resets, malformed logins, and safe quoted output.

Chores:
- Add database model, repository operations, and migrations for persistent autoshoutout entries and command configuration.