### PR TITLE
Autoshoutout trigger: channel-point redemptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ an `Action`, which is why the split holds: the loop reads a conclusion rather
 than watching the I/O that reached it.
 
 **An autoshoutout is one per person per stream, and the session remembers who.**
-`services/twitch/autoshoutout.py` owns the list, the rule and the three places
+`services/twitch/autoshoutout.py` owns the list, the rule and the four places
 someone can turn up. The rule is `_decide` and is pure, like
 `live_alert_cycle._decide`; the lookup is *inside* it, as `LOOK_UP`, because
 the cost guarantee — one query per distinct chatter per stream — is the rule
@@ -221,7 +221,10 @@ is — at the price of the wording being `!so`'s. An incoming raid is settled
 rather than shouted, because the raid handler's own `!so` already gave them
 one; that mark lives in `channel_raid` and not in the shoutout handler, which a
 mod's manual `!so` also reaches. `!aso` is the exception that calls `shoutout`
-directly, having a chat event already in hand.
+directly, having a chat event already in hand. A redemption is the third way of
+arriving and takes the ordinary path: any custom reward counts, including one
+still queued for approval or later refunded, because the point is that they
+turned up rather than what they bought.
 
 **The shared-chat guard runs before anything reads a chat line.** It used to sit
 below the command parse, which was harmless while a relayed line could only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ says so in the admin channel, because past it a redelivery can run twice.
 
 The cost of the freshness check is real and worse than "events are refused". A
 403 is a failed delivery, and enough of them revoke the subscription — of which
-five of the seven cannot be recreated from this repo. That is why the check sits
+six of the eight cannot be recreated from this repo. That is why the check sits
 *below* the verification handshake and applies to notifications alone: a wrong
 clock must not also refuse the resubscribe that repairs it.
 
@@ -182,12 +182,12 @@ Twitch documents no 4xx/5xx distinction anywhere, and revocation counts anything
 that is not a 2xx, so a 400 spends the failure budget exactly as a 500 does. That
 wrong justification was recorded here first; do not restore it.
 
-**Only two of the seven EventSub subscriptions can be created from this repo.**
+**Only two of the eight EventSub subscriptions can be created from this repo.**
 `/subscribe` creates `stream.online` and `stream.offline`. Chat, follow, ad break,
-raid and moderate are provisioned outside it, so a deployment whose public URL
-changes leaves five subscriptions pointing at a dead callback with nothing here
-able to recreate them. The startup check notices an undeliverable subscription;
-it cannot repair these five.
+raid, moderate and channel-point redemption are provisioned outside it, so a
+deployment whose public URL changes leaves six subscriptions pointing at a dead
+callback with nothing here able to recreate them. The startup check notices an
+undeliverable subscription; it cannot repair these six.
 
 **A live alert is closed by its updater, never by a webhook.** `stream.offline`
 carries no stream id, so the handler cannot tell which stream ended; it calls

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -22,6 +22,9 @@ from models.twitch_event_subs.channel_ad_break_begin import ChannelAdBreakBeginE
 from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
 from models.twitch_event_subs.channel_follow import ChannelFollowEventSub
 from models.twitch_event_subs.channel_moderate import ChannelModerateEventSub
+from models.twitch_event_subs.channel_points_custom_reward_redemption_add import (
+    ChannelPointsCustomRewardRedemptionAddEventSub,
+)
 from models.twitch_event_subs.channel_raid import ChannelRaidEventSub
 from models.twitch_event_subs.stream_offline import StreamOfflineEventSub
 from models.twitch_event_subs.stream_online import StreamOnlineEventSub
@@ -343,3 +346,8 @@ _route(
 )
 _route("/webhook/twitch/raid", ChannelRaidEventSub, events.channel_raid)
 _route("/webhook/twitch/moderate", ChannelModerateEventSub, events.channel_moderate)
+_route(
+    "/webhook/twitch/redemption",
+    ChannelPointsCustomRewardRedemptionAddEventSub,
+    events.channel_points_custom_reward_redemption_add,
+)

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -217,7 +217,7 @@ async def validate_call(request: Request, endpoint: str) -> dict[str, Any] | Res
     # Freshness applies to notifications alone, and deliberately sits below the
     # handshake. A wrong clock refusing events is recoverable; a wrong clock that
     # also refuses webhook_callback_verification would block the resubscribe that
-    # repairs it, and five of the seven subscriptions cannot be recreated from
+    # repairs it, and six of the eight subscriptions cannot be recreated from
     # this repo at all.
     try:
         sent = parse_rfc3339(headers.get(TWITCH_MESSAGE_TIMESTAMP, ""))

--- a/models/twitch_event_subs/channel_points_custom_reward_redemption_add.py
+++ b/models/twitch_event_subs/channel_points_custom_reward_redemption_add.py
@@ -1,0 +1,21 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ChannelPointsCustomRewardRedemptionAddSubscription(BaseModel):
+    type: Literal["channel.channel_points_custom_reward_redemption.add"]
+
+
+class ChannelPointsCustomRewardRedemptionAddEvent(BaseModel):
+    broadcaster_user_id: str
+    # The id matches the autoshoutout list, the login is what a `!so` line
+    # needs; user_name is the display name and is not modelled, because
+    # nothing here shows it.
+    user_id: str
+    user_login: str
+
+
+class ChannelPointsCustomRewardRedemptionAddEventSub(BaseModel):
+    subscription: ChannelPointsCustomRewardRedemptionAddSubscription
+    event: ChannelPointsCustomRewardRedemptionAddEvent

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -22,6 +22,9 @@ from enum import Enum, auto
 from db import repository
 from errors import notify, report
 from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
+from models.twitch_event_subs.channel_points_custom_reward_redemption_add import (
+    ChannelPointsCustomRewardRedemptionAddEventSub,
+)
 from services.config import config
 from services.present import quoted
 from services.twitch import stream_session
@@ -29,7 +32,7 @@ from services.twitch.chat import say
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["add", "chatted", "raided", "remove", "spend"]
+__all__ = ["add", "chatted", "raided", "redeemed", "remove", "spend"]
 
 
 class _Action(Enum):
@@ -59,6 +62,18 @@ def _decide(live: bool, settled: bool, listed: bool | None) -> _Action:
 
 async def _consider(broadcaster_id: str, twitch_user_id: int, login: str) -> None:
     """Give this person their autoshoutout, if this is the stream for it."""
+    # The main broadcaster's channel, not merely some channel that reached
+    # here. `is_live()` answers for the main broadcaster while the line below
+    # is posted to whoever the event named, and the two are otherwise
+    # unconnected: a chat or redemption subscription for a second channel -
+    # most are provisioned by hand, and the app already takes stream.online
+    # for other broadcasters - would put `!so` into that
+    # channel every time the main broadcaster happened to be live, and settle
+    # the person out of the autoshoutout they were actually owed. The same
+    # boundary `channel_raid` and `channel_moderate` already apply.
+    if not stream_session.is_main_broadcaster(broadcaster_id):
+        return
+
     if (
         _decide(
             stream_session.is_live(), stream_session.is_settled(twitch_user_id), None
@@ -146,6 +161,21 @@ def raided(twitch_user_id: str) -> None:
         stream_session.settle(int(twitch_user_id))
     except ValueError:
         logger.warning("Raider id %r is not a number; not settled", twitch_user_id)
+
+
+async def redeemed(event_sub: ChannelPointsCustomRewardRedemptionAddEventSub) -> None:
+    """Consider the redeemer behind one channel-point redemption.
+
+    Any custom reward counts, and one still queued or later refunded counts
+    too: the point is that they turned up, not what they bought. No guard of
+    its own, unlike `chatted` — nothing follows this on the notification, so
+    the handler's own report is the only one it needs.
+    """
+    await _consider(
+        event_sub.event.broadcaster_user_id,
+        int(event_sub.event.user_id),
+        event_sub.event.user_login,
+    )
 
 
 def spend(twitch_user_id: int) -> None:

--- a/services/twitch/autoshoutout.py
+++ b/services/twitch/autoshoutout.py
@@ -178,14 +178,21 @@ async def redeemed(event_sub: ChannelPointsCustomRewardRedemptionAddEventSub) ->
     )
 
 
-def spend(twitch_user_id: int) -> None:
+def spend(broadcaster_id: str, twitch_user_id: int) -> None:
     """Record that `!aso` has already given this person their autoshoutout.
 
     Only while a stream is running. `!aso` between streams still adds the row
     and still shouts them out, but there is no session for it to spend from,
     so their first appearance next stream earns them a proper one.
+
+    And only from the main broadcaster's channel, for the reason `_consider`
+    gives. Commands are answered wherever the bot has a chat subscription, and
+    a `!so` posted into that channel is a service to it; settling against this
+    session is not, because the session is the main broadcaster's. Taking the
+    broadcaster rather than reading it at the call site so that a second caller
+    cannot omit the check - the state this writes to belongs to one channel.
     """
-    if stream_session.is_live():
+    if stream_session.is_main_broadcaster(broadcaster_id) and stream_session.is_live():
         stream_session.settle(twitch_user_id)
 
 

--- a/services/twitch/commands.py
+++ b/services/twitch/commands.py
@@ -196,7 +196,7 @@ async def auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> Non
     # row stays either way: wanting them on the list is what `!aso` records,
     # and a shoutout Twitch could not complete does not undo that.
     if await shoutout(event_sub, args):
-        autoshoutout.spend(int(user.id))
+        autoshoutout.spend(event_sub.event.broadcaster_user_id, int(user.id))
 
 
 async def un_auto_shoutout(event_sub: ChannelChatMessageEventSub, args: str) -> None:

--- a/services/twitch/events.py
+++ b/services/twitch/events.py
@@ -15,6 +15,9 @@ from models.twitch_event_subs.channel_ad_break_begin import ChannelAdBreakBeginE
 from models.twitch_event_subs.channel_chat_message import ChannelChatMessageEventSub
 from models.twitch_event_subs.channel_follow import ChannelFollowEventSub
 from models.twitch_event_subs.channel_moderate import ChannelModerateEventSub
+from models.twitch_event_subs.channel_points_custom_reward_redemption_add import (
+    ChannelPointsCustomRewardRedemptionAddEventSub,
+)
 from models.twitch_event_subs.channel_raid import ChannelRaidEventSub
 from models.twitch_event_subs.stream_offline import StreamOfflineEventSub
 from models.twitch_event_subs.stream_online import StreamOnlineEventSub
@@ -191,6 +194,15 @@ async def channel_ad_break_begin(event_sub: ChannelAdBreakBeginEventSub) -> None
         stream_session.schedule_ad_break_warning(broadcaster_id)
     except Exception as e:  # noqa: BLE001
         await report(e, "Error processing Twitch ad break webhook task")
+
+
+async def channel_points_custom_reward_redemption_add(
+    event_sub: ChannelPointsCustomRewardRedemptionAddEventSub,
+) -> None:
+    try:
+        await autoshoutout.redeemed(event_sub)
+    except Exception as e:  # noqa: BLE001
+        await report(e, "Error processing Twitch redemption webhook task")
 
 
 async def channel_raid(event_sub: ChannelRaidEventSub) -> None:


### PR DESCRIPTION
Closes #22.

A channel-point redemption becomes the third way someone on the **autoshoutout list** can turn up and earn their **autoshoutout**, alongside chatting and raiding. One per person per **stream session**, same as the other two.

## How it works

An eighth EventSub subscription and its route. `redeemed` takes the ordinary path through `_consider`, so the rule, the once-per-stream guarantee and the cost guarantee — **one query per distinct person per stream** — are the ones chat already gets, rather than a second implementation of them.

It carries no guard of its own, unlike `chatted`. That guard exists because a command dispatch follows a chat line; nothing follows a redemption, so the handler's own `report` is the only one it needs, matching all seven other handlers in `events.py`.

**Any custom reward counts.** No `reward_id` in the condition, no `reward` field in the model, no branch in the handler. One still queued for approval or later refunded counts too: the point is that they showed up, not what they bought. Filtering by a nominated reward would live only in Twitch config — invisible here and unchangeable without re-provisioning; a configurable set of ids would be a config surface keyed by opaque GUIDs for a distinction nobody has asked for.

**Automatic rewards are out.** Separate subscription, separate payload, and the most common one — Highlight My Message — *is* a chat message, so the chat trigger already catches that redeemer.

The model carries three fields and no more, per the convention that an event models what its handler reads. A rename cannot move the id, so that is what matches the list; the login is what a `!so` line needs. `user_name` is the display name and nothing here shows it.

## Two broadcaster-identity bugs, found along the way

Both predate this branch. Neither was reachable in the current deployment, and both are the same defect.

`stream_session.is_live()` answers **"is the *main* broadcaster streaming"**. Two places then acted on that answer against a channel the event named instead, and nothing connected the two. The app already accepts `stream.online` for other broadcasters — that is what the `promo` channel is for — and six of the eight subscriptions are provisioned by hand, so a second channel's chat or redemption subscription is a live possibility rather than a hypothetical.

**1. `_consider` never checked the broadcaster** (caught by the Verity gate, which blocked the first commit). A chat or redemption subscription for a second channel would have put `!so` into *that* channel whenever the main broadcaster happened to be live, and settled the person out of the autoshoutout they were actually owed here. Fixed with one guard where both callers route through, rather than one per caller. **The chat trigger shared this and is fixed by the same line** — worth knowing when reading the diff, since that code shipped in #21.

**2. `spend` had the identical hole** (caught by an adversarial review of the branch). `!aso` settles against the main session, but commands are answered wherever the bot has a chat subscription and nothing in `auto_shoutout`, `dispatch` or `_run` looks at which broadcaster the line came from — `mod_only` is a badge check, not a channel one. A mod typing `!aso <someone>` in a second channel would spend that person's autoshoutout here. **And `!aso` could not repair it**: the row exists by then, so `add` answers `False` and no shoutout is given.

The guard went *inside* `spend`, which now takes the broadcaster, rather than at its one call site — the state it writes belongs to one channel and a second caller must not be able to omit the check. The `!so` itself still goes out: posting into the channel that asked is a service to it, and only the settling was ever wrong.

## Human prerequisite

**A person must create the subscription by hand.** `/subscribe` only creates the `stream.online`/`stream.offline` pair, so this is the **sixth of eight** provisioned outside this repo.

- Type `channel.channel_points_custom_reward_redemption.add`, version `1`
- Condition: `broadcaster_user_id` only, no `reward_id`
- Needs the **broadcaster** token with `channel:read:redemptions`. That scope is in `twitch_app_scopes` (seeded in revision 0002), but the existing grant has been *assumed* to carry it, not verified. If the create returns 401/403 on scopes, re-run `/twitch-auth` for the broadcaster first.

`AGENTS.md` is updated to eight total / six hand-provisioned in all three places the count is stated, so the orphaned-callback warning stays honest. No change was needed to the undeliverable check: `broken_subscriptions()` reads every subscription unfiltered, so the hourly loop picks this one up on its own.

## Verification

Four checks clean in order. Verity gate **PASS taken while uncommitted before each of the three commits** — the first commit was blocked by the gate on bug 1 above and only landed once it was fixed.

A new harness covers offline, on-list, repeat-in-the-same-stream, chat-after-redeem, not-on-list ×20 proving one query, new-stream reset, malformed login, wrong-event-type parse failure, route wiring, and both foreign-broadcaster cases. A second harness proves the `spend` guard three ways. Seven existing harnesses re-run green; two needed updating for `spend`'s new signature.

An adversarial Sonnet review of the whole branch validated the new model against Twitch's documented payload, and confirmed the guard is sound on the startup-ordering question — before `config.load()`, `is_main_broadcaster` returns `False`, but `is_live()` cannot be `True` then either, so there is no window where the guard changes the outcome.

**There is no test suite, so this is not tested.** EventSub cannot reach `localhost` without the tunnel, so this trigger cannot fire in local development at all — **it has never seen a real redemption**, and the model's field names are verified against Twitch's docs rather than against a live delivery.

## Notes

- #22 says the model should be "exported from `models/__init__.py`". That instruction is stale: the file deliberately re-exports nothing now, and none of the seven sibling models are there either. Followed the codebase.
- #40 and #41 were filed for the two Verity MEDIUMs on `controller/twitch.py` (`validate_call` and `process_webhook`). Both pre-existing; this branch only adds an import and a `_route` call to that file.
- `raided` catches a `ValueError` into a bare `logger.warning` rather than the admin channel, against the convention. Pre-existing from #21, and unreachable since Twitch ids are numeric. Left alone; `notify_soon` is the fix if wanted, `raided` being synchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support autoshoutouts triggered by channel-point redemptions while enforcing broadcaster-specific session boundaries.

New Features:
- Add channel-point redemption events as a fourth way for listed users to receive an autoshoutout, with a dedicated EventSub model, handler, and webhook route.

Bug Fixes:
- Prevent chat, redemption, and manual autoshoutout actions from affecting the main stream session when events or commands originate from another broadcaster’s channel.

Enhancements:
- Route redemptions through the existing autoshoutout eligibility, once-per-stream, and lookup logic without reward-specific filtering.

Documentation:
- Update operational documentation for the additional EventSub subscription and hand-provisioned subscription counts.