### PR TITLE
Repoint every EventSub subscription when the public URL changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,47 @@ lives only in Twitch. `services/twitch/migrate.py` therefore starts from
 silently leave every promo broadcaster behind. Its rule is `decide`, which is pure,
 like `live_alert_cycle._decide`.
 
+**`decide` reads the callback and deliberately ignores the status.** It once
+repointed anything not `enabled` even when the callback was already right, on the
+reasoning that a disabled subscription delivers nothing whatever its callback says
+— true, and not this command's problem, because what that bought was a
+delete-then-create on a subscription already pointing where it should.
+`webhook_callback_verification_pending` is a seconds-long transient on the way to
+`enabled`, so catching one mid-verification destroyed something about to arrive by
+itself; `authorization_revoked` and the `*_removed` statuses are not things
+recreating repairs, so the delete turned a subscription still visible in
+`get_subscriptions()` into one that is gone. A correct callback that is not
+delivering is already `undeliverable`, which `recheck_subscriptions` reports hourly
+— that check owns the problem, this one owns the callback. Do not restore the
+status condition.
+
+**A 409 on the recreate is checked against Helix before it is called a loss.**
+`create_subscription` is `repeatable`, so a POST whose reply was lost is re-sent
+and Twitch answers the retry 409 *because the first attempt created it*. A 409
+therefore says the subscription exists at least as often as it says something else
+got there first, and reporting it as destroyed would send somebody to hand-recreate
+a subscription already in place — where, for the six types provisioned outside this
+repo, the attempt 409s too. `_exists_at` answers False when its own lookup fails:
+over-reporting a loss costs a needless check, under-reporting one costs a
+subscription nobody knows is missing.
+
+**A failed delete and a failed create are different outcomes and are reported
+apart.** `stuck` did not move and is still delivering on the old callback, so
+re-running is the whole remedy; `lost` is destroyed, and for six of the eight types
+the dump is the only way back. One list for both made a working subscription and a
+destroyed one read identically in the reply an operator sees first, which is the
+one moment that distinction matters.
+
+**A second confirmed run refuses while one is in flight.** Two would interleave
+deletes and creates over the same subscriptions: the loser of a delete race is
+reported untouched when it was destroyed, and the loser of a create race gets a 409
+that no longer means what the check above assumes. A plain module flag rather than
+an `asyncio.Lock`, because what is wanted is refusal and a lock queues — and a run
+that waits and then finds nothing to do looks exactly like one that was not needed.
+Taken with no await between the check and the set, for the reason
+`controller/twitch.py`'s `_claim` is one step. A dry run is not guarded: it changes
+nothing.
+
 Twitch's uniqueness key is the type and the condition **alone, not the transport**,
 so the same event at a new callback is a 409 and repointing has to be delete-then-
 create. Three consequences the module is built around, none of them optional: the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,12 +182,48 @@ Twitch documents no 4xx/5xx distinction anywhere, and revocation counts anything
 that is not a 2xx, so a 400 spends the failure budget exactly as a 500 does. That
 wrong justification was recorded here first; do not restore it.
 
-**Only two of the eight EventSub subscriptions can be created from this repo.**
+**Only two of the eight EventSub subscriptions can be created from nothing.**
 `/subscribe` creates `stream.online` and `stream.offline`. Chat, follow, ad break,
-raid, moderate and channel-point redemption are provisioned outside it, so a
-deployment whose public URL changes leaves six subscriptions pointing at a dead
-callback with nothing here able to recreate them. The startup check notices an
-undeliverable subscription; it cannot repair these six.
+raid, moderate and channel-point redemption are provisioned outside this repo, so
+nothing here can bring one back once it is gone. **Repointing an existing one is
+different, and covered:** `/migrate-subscriptions` moves all eight types to the
+current `APP_URL`, which is what a deployment whose public URL changes needs. The
+startup check notices an undeliverable subscription; the command is what repairs it.
+
+**The migration works off the live list, never a fixed one.** There are eight
+*types* but `6 + 2N` *subscriptions* — `stream.online`/`stream.offline` exist once
+per subscribed broadcaster, and nothing here knows what N is, because that list
+lives only in Twitch. `services/twitch/migrate.py` therefore starts from
+`get_subscriptions()`; a migration seeded from a list written in this repo would
+silently leave every promo broadcaster behind. Its rule is `decide`, which is pure,
+like `live_alert_cycle._decide`.
+
+Twitch's uniqueness key is the type and the condition **alone, not the transport**,
+so the same event at a new callback is a 409 and repointing has to be delete-then-
+create. Three consequences the module is built around, none of them optional: the
+complete definition of every subscription goes to the admin channel as a file
+*before* anything is deleted, since after the delete it is the only record one
+existed; a failure is reported per subscription and does not abandon the ones
+behind it; and a dry run is what you get unless you pass `confirm`. A type with no
+route is reported and **left alone** — deleting it would destroy something created
+deliberately elsewhere, and nothing here could recreate it.
+
+`SubscriptionCondition` is the one model here that keeps what it does not declare
+(`extra="allow"`), and that is the migration's doing rather than an oversight. Its
+five keys cover the eight subscriptions in use, so declaring them is what lets the
+rest of the code read one by name; but a condition is now *round-tripped* to
+recreate a subscription, and a key outside those five — a `reward_id`, or anything
+Twitch adds — would otherwise be dropped in silence and recreate a subscription
+**broader than the one it replaced**, with nothing to say so. This is the opposite
+of the rule for EventSub payload models above, and for the opposite reason: those
+are read, this one is written back.
+
+**`WEBHOOK_PATHS` is derived from the `_route` table, not written beside it.**
+`controller/twitch.py` builds it as the routes register, reading each type off the
+`Literal` its model already declares — a ninth list of the eight types is one more
+thing to keep in step by hand. It is passed *into* `migrate`, never imported by it,
+because nothing under `services/` may import `controller/`; `cogs/admin.py` may,
+and is what hands it over.
 
 **A live alert is closed by its updater, never by a webhook.** `stream.offline`
 carries no stream id, so the handler cannot tell which stream ended; it calls
@@ -363,10 +399,15 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
 - **Everything the bot says about itself goes through `errors.py`.** `report(exc,
   context)` for an exception, `notify(text)` for anything else worth the admin
   channel, `notify_soon(text)` for the two synchronous renderers that cannot
-  await. None of them raise, all log locally first, and all say so when the
-  channel is out of reach. `notify` returns whether the channel has the news, for
-  the one caller that retries. Nothing else may resolve
+  await, `notify_file(text, filename, content)` for a notice carrying a record
+  too long for a message. None of them raise, all log locally first, and all say
+  so when the channel is out of reach. `notify` returns whether the channel has
+  the news, for the one caller that retries. Nothing else may resolve
   `config.channel("bot_admin")`.
+  `notify_file` is the one that deliberately skips the fifteen-minute repeat
+  window: it carries what somebody needs in order to undo what the bot is about
+  to do, and two inside one window are two different records, so standing the
+  second in for the first would leave a destruction with nothing to reverse it.
 - **A path that degrades or gives up says so in the admin channel.** Catching a
   `HelixError` to carry on without an avatar is fine; catching it into
   `logger.warning` alone is not. The logs are not watched and the Discord server

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -14,6 +14,7 @@ from discord.ext.commands import Bot, Cog
 from discord.utils import escape_markdown
 
 from constants import TokenType
+from controller.twitch import WEBHOOK_PATHS
 from errors import report
 from services.config import config
 from services.present import quoted
@@ -25,6 +26,7 @@ from services.twitch.api import (
     unsubscribe_to_user,
 )
 from services.twitch.helix import HelixError
+from services.twitch.migrate import migrate, summary
 from services.twitch.oauth import create_authorization_start_url
 from views import role_panels
 
@@ -282,6 +284,39 @@ class Admin(Cog):
             if found
             else f"No Twitch user called {escape_markdown(login)}"
         )
+
+    @app_commands.command(
+        name="migrate-subscriptions",
+        description="Repoint every EventSub subscription at this deployment's URL",
+    )
+    @app_commands.commands.default_permissions(administrator=True)
+    @app_commands.describe(
+        confirm="Actually do it. Without this it reports what it would do and stops.",
+    )
+    async def migrate_subscriptions(
+        self, interaction: Interaction, confirm: bool = False
+    ) -> None:
+        if interaction.user.id != config.setting("owner_id"):
+            await interaction.response.send_message(
+                "Only the configured bot owner can migrate Twitch subscriptions.",
+                ephemeral=True,
+            )
+            return
+
+        # Helix is asked once per subscription and then twice more per repoint,
+        # which is well past Discord's three seconds.
+        await interaction.response.defer(ephemeral=True)
+        try:
+            outcome = await migrate(WEBHOOK_PATHS, confirm=confirm)
+        except HelixError as e:
+            await report(e, "Failed to migrate Twitch subscriptions")
+            await interaction.followup.send(
+                "Could not reach Twitch to list the subscriptions, so nothing was"
+                " touched."
+            )
+            return
+
+        await interaction.followup.send(summary(outcome, confirm=confirm))
 
     @app_commands.command(
         description="Unsubscribe from online and offline events for a user"

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, get_args
 
 import pendulum
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -313,6 +313,31 @@ async def process_webhook[E: BaseModel](
         raise HTTPException(status_code=500) from e
 
 
+# Which webhook path serves each EventSub type. Derived from the routes below
+# rather than listed beside them, so it cannot drift from them: a ninth list of
+# the eight types is one more thing to keep in step by hand. Read by
+# services/twitch/migrate.py, which is handed this rather than importing it,
+# since nothing under services/ may import controller/.
+WEBHOOK_PATHS: dict[str, str] = {}
+
+
+def _subscription_type(event_model: type[BaseModel]) -> str:
+    """The EventSub type a model serves, read off the Literal that asserts it.
+
+    Raises at import, which is the point: a model that stopped declaring exactly
+    one type would otherwise leave its route out of WEBHOOK_PATHS, and a type
+    missing from that map is one the migration declines to touch.
+    """
+    subscription = event_model.model_fields["subscription"].annotation
+    if not isinstance(subscription, type) or not issubclass(subscription, BaseModel):
+        raise TypeError(f"{event_model.__name__}.subscription is not a model")
+
+    declared = get_args(subscription.model_fields["type"].annotation)
+    if len(declared) != 1 or not isinstance(declared[0], str):
+        raise TypeError(f"{subscription.__name__}.type is not a single-value Literal")
+    return declared[0]
+
+
 def _route[E: BaseModel](
     path: str,
     event_model: type[E],
@@ -328,6 +353,8 @@ def _route[E: BaseModel](
 
     async def webhook(request: Request) -> Response:
         return await process_webhook(request, path, event_model, task_func)
+
+    WEBHOOK_PATHS[_subscription_type(event_model)] = path
 
     # Applied as a call rather than as a decorator: every route's function is
     # named "webhook", so each needs a name of its own for url_for and the

--- a/controller/twitch.py
+++ b/controller/twitch.py
@@ -354,7 +354,18 @@ def _route[E: BaseModel](
     async def webhook(request: Request) -> Response:
         return await process_webhook(request, path, event_model, task_func)
 
-    WEBHOOK_PATHS[_subscription_type(event_model)] = path
+    # Refused rather than overwritten, because a plain assignment makes the one
+    # kind of drift this map exists to prevent the silent kind: two models
+    # declaring the same type would leave the migration repointing every
+    # subscription of it at whichever route registered last, with the other route
+    # missing from the map and so never migrated at all.
+    subscription_type = _subscription_type(event_model)
+    if subscription_type in WEBHOOK_PATHS:
+        raise ValueError(
+            f"{subscription_type} is already routed to"
+            f" {WEBHOOK_PATHS[subscription_type]}, so {path} would replace it"
+        )
+    WEBHOOK_PATHS[subscription_type] = path
 
     # Applied as a call rather than as a decorator: every route's function is
     # named "webhook", so each needs a name of its own for url_for and the

--- a/errors.py
+++ b/errors.py
@@ -1,6 +1,6 @@
 """Everything the bot says about itself, in one place.
 
-Neither function raises. Both run inside somebody's ``except`` block, where an
+None of these raise. They run inside somebody's ``except`` block, where an
 escaping exception would replace the one being reported, and a lost report is
 worse than an ugly one.
 
@@ -69,7 +69,7 @@ def _prune(now: float) -> None:
             del _windows[key]
 
 
-async def _send_once(key: str, text: str, trace: str | None) -> bool:
+async def _send_once(key: str, text: str, attachment: tuple[str, str] | None) -> bool:
     """Deliver unless an identical message already did, inside the window."""
     now = time.monotonic()
     _prune(now)
@@ -95,7 +95,7 @@ async def _send_once(key: str, text: str, trace: str | None) -> bool:
 
     sent = False
     try:
-        sent = await _deliver(text, trace)
+        sent = await _deliver(text, attachment)
     finally:
         # In a finally because a _deliver that raises has delivered nothing
         # either, and leaving its window standing would suppress the retry —
@@ -119,7 +119,11 @@ async def report(exc: Exception, context: str, *, key: str | None = None) -> Non
         logger.error("%r\nTraceback:\n%s", summary, trace)
         # Context names the thing that failed; the type keeps two different
         # failures reported from one place from standing in for each other.
-        await _send_once(key or f"{context}\x00{type(exc).__name__}", summary, trace)
+        await _send_once(
+            key or f"{context}\x00{type(exc).__name__}",
+            summary,
+            ("traceback.txt", trace),
+        )
     except Exception:
         # Describing an exception can itself fail: a __str__ that raises, or a
         # services import that never completed.
@@ -141,6 +145,22 @@ async def notify(text: str, *, key: str | None = None) -> bool:
         # that a notice was raised at all.
         logger.info("%r", text)
         return await _send_once(key or text, text, None)
+    except Exception:
+        logger.exception("Notifying failed for: %r", text)
+        return False
+
+
+async def notify_file(text: str, filename: str, content: str) -> bool:
+    """Deliver a notice with a file attached, never held back as a repeat.
+
+    The window is deliberately skipped rather than keyed around. This carries a
+    record somebody needs in order to undo what the bot is about to do, and two
+    of them inside one window are two different records -- suppressing the
+    second would leave the destruction it precedes with nothing to reverse it.
+    """
+    try:
+        logger.info("%r (attached %s, %d characters)", text, filename, len(content))
+        return await _deliver(text, (filename, content))
     except Exception:
         logger.exception("Notifying failed for: %r", text)
         return False
@@ -168,7 +188,7 @@ def notify_soon(text: str, *, key: str | None = None) -> None:
     fire_and_forget(notify(text, key=key), name="notify")
 
 
-async def _deliver(text: str, trace: str | None) -> bool:
+async def _deliver(text: str, attachment: tuple[str, str] | None) -> bool:
     # Deferred: importing services at module scope runs the whole package, and
     # main.py reports cog-load failures before any of it is up.
     from services.config import config
@@ -182,11 +202,10 @@ async def _deliver(text: str, trace: str | None) -> bool:
 
     from services.send import send_message
 
-    file = (
-        discord.File(io.BytesIO(trace.encode("utf-8")), filename="traceback.txt")
-        if trace is not None
-        else None
-    )
+    file = None
+    if attachment is not None:
+        filename, content = attachment
+        file = discord.File(io.BytesIO(content.encode("utf-8")), filename=filename)
     # quiet: send_message announces a channel it cannot resolve, and announcing
     # this one goes through here again.
     if _undelivered:

--- a/models/twitch_api_responses/subscription.py
+++ b/models/twitch_api_responses/subscription.py
@@ -1,9 +1,17 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from .pagination import Pagination
 
 
 class SubscriptionCondition(BaseModel):
+    # Undeclared keys are kept rather than dropped, because a condition is
+    # round-tripped to recreate a subscription at a new callback. The five below
+    # cover the eight subscriptions in use, so declaring them is what lets the
+    # rest of the code read one by name; anything Twitch adds -- a reward_id on a
+    # redemption, say -- would otherwise vanish silently on the way through and
+    # recreate a subscription broader than the one it replaced.
+    model_config = ConfigDict(extra="allow")
+
     broadcaster_user_id: str | None = None
     # A raid is keyed on the two ends rather than one broadcaster, and a
     # moderate subscription carries the moderator as well.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # discord.py sends on aiohttp; live_alert names its errors directly, so it is
     # declared here rather than leaned on transitively.
     "aiohttp>=3.14.3",
-    "alembic>=1.19.2",
+    "alembic>=1.20.0",
     "asyncpg>=0.31.0",
     "discord>=2.3.2",
     "fastapi>=0.141.1",

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -149,8 +149,11 @@ async def send_shoutout(to_broadcaster_id: str) -> None:
 def callback_prefix() -> str:
     """What every EventSub callback for this deployment starts with.
 
-    All seven webhook routes live under it, so a callback that does not begin
-    here belongs to another deployment or to this one before it moved.
+    Every webhook route begins with it, so a callback that does not begin here
+    belongs to another deployment or to this one before it moved. Deliberately
+    not a count: this said "seven" from the commit that added the check until the
+    eighth route landed in controller/twitch.py without touching this file, which
+    is exactly what a number written down in the wrong module does.
     """
     return callback_url("/webhook/twitch")
 

--- a/services/twitch/api.py
+++ b/services/twitch/api.py
@@ -6,7 +6,7 @@ complete raises ``HelixError``. The two are no longer the same answer.
 
 import itertools
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 from config import settings
 from constants import TokenType
@@ -150,12 +150,19 @@ def callback_prefix() -> str:
     """What every EventSub callback for this deployment starts with.
 
     All seven webhook routes live under it, so a callback that does not begin
-    here belongs to another deployment or to this one before it moved. rstrip
-    to match services/twitch/oauth.py: a trailing slash in APP_URL would
+    here belongs to another deployment or to this one before it moved.
+    """
+    return callback_url("/webhook/twitch")
+
+
+def callback_url(path: str) -> str:
+    """The absolute callback this deployment answers one webhook path on.
+
+    rstrip to match services/twitch/oauth.py: a trailing slash in APP_URL would
     otherwise build a //webhook/twitch that Twitch dutifully calls and FastAPI
     does not route.
     """
-    return f"{settings.app_url.rstrip('/')}/webhook/twitch"
+    return f"{settings.app_url.rstrip('/')}{path}"
 
 
 def _callback_url(sub_type: Literal["online", "offline"]) -> str:
@@ -173,25 +180,49 @@ async def _matching_subscriptions(
     ]
 
 
-async def _create_subscription(
-    sub_type: Literal["online", "offline"], user_id: str
+async def create_subscription(
+    sub_type: str, version: str, condition: dict[str, Any], callback: str
 ) -> None:
-    # Repeatable: Twitch rejects a duplicate rather than creating a second, so
-    # the worst a repeat costs is the 409 its caller handles. See docs/adr/0002.
+    """Create one EventSub subscription of any type, at this callback.
+
+    ``version`` is the caller's because it varies by type -- channel.follow and
+    channel.moderate are 2, the rest are 1 -- and a subscription being recreated
+    carries its own, which is the only one that reproduces it.
+
+    Repeatable: Twitch rejects a duplicate rather than creating a second, so the
+    worst a repeat costs is the 409 its caller handles. See docs/adr/0002.
+    """
     await helix.request(
         "POST",
         "/eventsub/subscriptions",
         json={
-            "type": f"stream.{sub_type}",
-            "version": "1",
-            "condition": {"broadcaster_user_id": user_id},
+            "type": sub_type,
+            "version": version,
+            "condition": condition,
             "transport": {
                 "method": "webhook",
-                "callback": _callback_url(sub_type),
+                "callback": callback,
                 "secret": settings.twitch_webhook_secret,
             },
         },
         repeatable=True,
+    )
+
+
+async def delete_subscription(subscription_id: str) -> None:
+    await helix.request(
+        "DELETE", "/eventsub/subscriptions", params={"id": subscription_id}
+    )
+
+
+async def _create_subscription(
+    sub_type: Literal["online", "offline"], user_id: str
+) -> None:
+    await create_subscription(
+        f"stream.{sub_type}",
+        "1",
+        {"broadcaster_user_id": user_id},
+        _callback_url(sub_type),
     )
 
 
@@ -231,17 +262,37 @@ async def _subscribe(sub_type: Literal["online", "offline"], user_id: str) -> No
             f" {subscription.transport.callback}, so it was delivering nothing.",
             key=f"subscription-replaced:{sub_type}:{user_id}",
         )
-        await helix.request(
-            "DELETE", "/eventsub/subscriptions", params={"id": subscription.id}
-        )
+        await delete_subscription(subscription.id)
     await _create_subscription(sub_type, user_id)
+
+
+async def _named_user(username: str) -> User | None:
+    """The user this names, or None -- refusing anything that cannot name one.
+
+    The grammar is asked for here rather than trusted from the caller: these two
+    are public, and a value that cannot name a channel should reach neither a
+    Helix query parameter nor a log line on the strength of having been passed
+    in. Deferred because services.twitch.commands imports this module; it owns
+    the one grammar, and a second copy here is what issue #38 is about.
+
+    %r throughout, as everywhere else that logs a relayed value: a newline in
+    one would otherwise forge a log line.
+    """
+    from services.twitch.commands import is_twitch_login
+
+    if not is_twitch_login(username):
+        logger.warning("Not a Twitch login, no lookup made: %r", username)
+        return None
+    user = await get_user_by_username(username)
+    if not user:
+        logger.warning("User not found: %r", username)
+    return user
 
 
 async def subscribe_to_user(username: str) -> bool:
     """False when Twitch has no such user; a failed call raises."""
-    user = await get_user_by_username(username)
+    user = await _named_user(username)
     if not user:
-        logger.warning(f"User not found: {username}")
         return False
 
     await _subscribe("online", user.id)
@@ -251,9 +302,8 @@ async def subscribe_to_user(username: str) -> bool:
 
 async def unsubscribe_to_user(username: str) -> bool:
     """False when Twitch has no such user; a failed call raises."""
-    user = await get_user_by_username(username)
+    user = await _named_user(username)
     if not user:
-        logger.warning(f"User not found: {username}")
         return False
 
     matching = [
@@ -263,13 +313,11 @@ async def unsubscribe_to_user(username: str) -> bool:
         and subscription.condition.broadcaster_user_id == user.id
     ]
     if not matching:
-        logger.info(f"No online/offline subscriptions found for user: {username}")
+        logger.info("No online/offline subscriptions for user: %r", username)
         return True
 
     for subscription in matching:
-        await helix.request(
-            "DELETE", "/eventsub/subscriptions", params={"id": subscription.id}
-        )
+        await delete_subscription(subscription.id)
     return True
 
 

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -28,7 +28,6 @@ from services.twitch.api import (
     delete_subscription,
     get_subscriptions,
     get_users,
-    subscription_target,
 )
 from services.twitch.helix import HelixError
 
@@ -99,12 +98,14 @@ class Outcome:
     logins: dict[str, str] = field(default_factory=dict)
 
 
+# Every condition field that carries a Twitch user id, with how to say it. The
+# labels match subscription_target's wording, which names only one of them.
 _CONDITION_ID_FIELDS = (
-    "broadcaster_user_id",
-    "to_broadcaster_user_id",
-    "from_broadcaster_user_id",
-    "moderator_user_id",
-    "user_id",
+    ("broadcaster_user_id", "broadcaster"),
+    ("to_broadcaster_user_id", "to broadcaster"),
+    ("from_broadcaster_user_id", "from broadcaster"),
+    ("moderator_user_id", "moderator"),
+    ("user_id", "user"),
 )
 
 
@@ -122,7 +123,7 @@ def _condition_ids(subscriptions: list[Subscription]) -> list[str]:
     ids = {
         value
         for subscription in subscriptions
-        for name in _CONDITION_ID_FIELDS
+        for name, _ in _CONDITION_ID_FIELDS
         if isinstance(value := getattr(subscription.condition, name, None), str)
     }
     return sorted(ids)
@@ -170,7 +171,7 @@ def render_dump(
                 "condition": condition_of(subscription),
                 "logins": {
                     value: logins[value]
-                    for name in _CONDITION_ID_FIELDS
+                    for name, _ in _CONDITION_ID_FIELDS
                     if isinstance(
                         value := getattr(subscription.condition, name, None), str
                     )
@@ -193,22 +194,27 @@ def render_dump(
 def describe(subscription: Subscription, logins: Mapping[str, str]) -> str:
     """One subscription, named the way a person would look for it.
 
-    Matched on the id subscription_target actually chose, and on the whole of it:
-    a Twitch id is a run of digits, so one is a substring of another often enough
-    that searching the rendered label would confidently name the wrong person.
+    Every id the condition carries, not only the first. Twitch's uniqueness key
+    is the type and the condition, so two subscriptions of one type against one
+    broadcaster are legitimate as long as another id differs -- two
+    channel.moderate for different moderators, or two channel.chat.message for
+    different reading users. Naming the broadcaster alone rendered those
+    identically, and a failure list is exactly where telling them apart matters.
+
+    Hence not ``subscription_target``, which answers with one id by design and is
+    right for the undeliverable summaries it serves. Building on it here meant
+    matching its rendered text to find out which id it had picked, which is a
+    thing to get wrong for no gain.
     """
-    target = subscription_target(subscription)
-    login = next(
-        (
-            logins[value]
-            for name in _CONDITION_ID_FIELDS
-            if isinstance(value := getattr(subscription.condition, name, None), str)
-            and target.endswith(f" {value}")
-            and value in logins
-        ),
-        None,
-    )
-    return f"{subscription.type} ({target}{f' = {login}' if login else ''})"
+    named = [
+        f"{label} {value}" + (f" = {logins[value]}" if value in logins else "")
+        for name, label in _CONDITION_ID_FIELDS
+        if isinstance(value := getattr(subscription.condition, name, None), str)
+    ]
+    # A condition naming nobody is not one of the eight, but it still has to be
+    # reportable: the id is all Twitch gives that is certain to identify it.
+    inside = ", ".join(named) or f"id {subscription.id}"
+    return f"{subscription.type} ({inside})"
 
 
 # Discord refuses a message over 2000 characters. The summary is the one reply

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -1,0 +1,375 @@
+"""Repointing every EventSub subscription at this deployment's callback host.
+
+Works off the live subscription list and never a fixed one. There are eight
+subscription *types* but more than eight subscriptions: ``stream.online`` and
+``stream.offline`` exist once per subscribed broadcaster, and nothing in this
+repo knows how many that is -- Twitch is the only authority on it, so anything
+working from a list written here would silently leave the rest behind.
+
+Twitch's uniqueness key is the type and the condition alone, not the transport,
+so a second subscription for one event at a new callback is a 409. Repointing is
+therefore delete-then-create, which is destructive in a way this module is built
+around: the dump goes out before anything is deleted, one failure does not
+abandon the rest, and a dry run is what you get unless you ask otherwise.
+"""
+
+import json
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from errors import notify, notify_file
+from models.twitch_api_responses.subscription import Subscription
+from services.twitch.api import (
+    callback_url,
+    create_subscription,
+    delete_subscription,
+    get_subscriptions,
+    get_users,
+    subscription_target,
+)
+from services.twitch.helix import HelixError
+
+logger = logging.getLogger(__name__)
+
+
+class Action(StrEnum):
+    """What this deployment should do with one existing subscription."""
+
+    REPOINT = "repoint"
+    KEEP = "already current"
+    # Something a person created deliberately that this deployment has no route
+    # for. Reported and left alone: deleting it would destroy it for good, and a
+    # recreate this end cannot address would not bring it back.
+    SKIP = "no route for this type"
+
+
+def decide(subscription: Subscription, routes: Mapping[str, str]) -> Action:
+    """What to do with this subscription. Pure, and the whole rule.
+
+    KEEP is status-aware because a subscription Twitch disabled delivers nothing
+    however right its callback looks, and leaving one behind is the failure this
+    command exists to end. A disabled subscription on the correct callback is
+    still repointed, which recreates it enabled.
+    """
+    path = routes.get(subscription.type)
+    if path is None:
+        return Action.SKIP
+    if subscription.status == "enabled" and subscription.transport.callback == (
+        callback_url(path)
+    ):
+        return Action.KEEP
+    return Action.REPOINT
+
+
+@dataclass
+class Outcome:
+    """What one migration pass found, and then did."""
+
+    repoint: list[Subscription] = field(default_factory=list)
+    keep: list[Subscription] = field(default_factory=list)
+    skip: list[Subscription] = field(default_factory=list)
+    migrated: list[Subscription] = field(default_factory=list)
+    # Subscriptions that are now gone: the delete landed and the create did not.
+    lost: list[tuple[Subscription, str]] = field(default_factory=list)
+    dumped: bool = False
+    # Carried so the caller names people rather than ids, without asking Helix
+    # the same question a second time.
+    logins: dict[str, str] = field(default_factory=dict)
+
+
+_CONDITION_ID_FIELDS = (
+    "broadcaster_user_id",
+    "to_broadcaster_user_id",
+    "from_broadcaster_user_id",
+    "moderator_user_id",
+    "user_id",
+)
+
+
+def condition_of(subscription: Subscription) -> dict[str, Any]:
+    """The condition as Twitch sent it, including keys the model does not declare.
+
+    ``exclude_none`` rather than a field list: the five declared keys default to
+    None and only some are set per type, while extras carry no default at all.
+    """
+    return subscription.condition.model_dump(exclude_none=True)
+
+
+def _condition_ids(subscriptions: list[Subscription]) -> list[str]:
+    """Every distinct Twitch user id named by any of these conditions."""
+    ids = {
+        value
+        for subscription in subscriptions
+        for name in _CONDITION_ID_FIELDS
+        if isinstance(value := getattr(subscription.condition, name, None), str)
+    }
+    return sorted(ids)
+
+
+async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
+    """Twitch id to login for everyone these subscriptions name.
+
+    A dump without this is not enough to recover by hand: a subscription stores
+    a user id, while ``/subscribe`` takes a login. A lookup that fails costs the
+    names and not the dump, which is the part that cannot be reconstructed.
+    """
+    ids = _condition_ids(subscriptions)
+    if not ids:
+        return {}
+    try:
+        return {user.id: user.login for user in await get_users(ids)}
+    except HelixError as e:
+        await notify(
+            f"Could not resolve {len(ids)} Twitch id(s) to logins for the"
+            f" subscription dump, so it names ids only: {e}",
+            key="migrate-dump-logins",
+        )
+        return {}
+
+
+def render_dump(
+    subscriptions: list[Subscription],
+    routes: Mapping[str, str],
+    logins: Mapping[str, str],
+) -> str:
+    """The complete definition of every subscription, as JSON somebody can act on.
+
+    Everything needed to recreate one by hand is here -- type, version, the full
+    condition, and the login behind each id -- because after the delete this is
+    the only record that it existed.
+    """
+    return json.dumps(
+        [
+            {
+                "id": subscription.id,
+                "type": subscription.type,
+                "version": subscription.version,
+                "status": subscription.status,
+                "condition": condition_of(subscription),
+                "logins": {
+                    value: logins[value]
+                    for name in _CONDITION_ID_FIELDS
+                    if isinstance(
+                        value := getattr(subscription.condition, name, None), str
+                    )
+                    and value in logins
+                },
+                "callback_now": subscription.transport.callback,
+                "callback_after": (
+                    callback_url(path)
+                    if (path := routes.get(subscription.type))
+                    else None
+                ),
+                "action": decide(subscription, routes).value,
+            }
+            for subscription in subscriptions
+        ],
+        indent=2,
+    )
+
+
+def describe(subscription: Subscription, logins: Mapping[str, str]) -> str:
+    """One subscription, named the way a person would look for it.
+
+    Matched on the id subscription_target actually chose, and on the whole of it:
+    a Twitch id is a run of digits, so one is a substring of another often enough
+    that searching the rendered label would confidently name the wrong person.
+    """
+    target = subscription_target(subscription)
+    login = next(
+        (
+            logins[value]
+            for name in _CONDITION_ID_FIELDS
+            if isinstance(value := getattr(subscription.condition, name, None), str)
+            and target.endswith(f" {value}")
+            and value in logins
+        ),
+        None,
+    )
+    return f"{subscription.type} ({target}{f' = {login}' if login else ''})"
+
+
+# Discord refuses a message over 2000 characters. The summary is the one reply
+# whose length follows how many subscriptions exist, so it is the one that can
+# reach it; the dump it points at is a file and has no such limit.
+_DISCORD_MESSAGE_LIMIT = 1990
+
+
+def _listed(
+    heading: str, subscriptions: list[Subscription], logins: Mapping[str, str]
+) -> list[str]:
+    return [heading, *(f"- {describe(s, logins)}" for s in subscriptions)]
+
+
+def summary(outcome: Outcome, *, confirm: bool) -> str:
+    """What the pass found, and did. Rendered here rather than by the caller, so
+    the thing that knows what an Outcome means is what says it out loud."""
+    if not outcome.repoint:
+        left_alone = f", {len(outcome.skip)} left alone" if outcome.skip else ""
+        return (
+            f"Nothing to migrate: {len(outcome.keep)} subscription(s) already"
+            f" call back on this deployment{left_alone}."
+        )
+
+    lines: list[str] = []
+    if confirm:
+        lines.append(f"Repointed {len(outcome.migrated)}/{len(outcome.repoint)}.")
+        if outcome.lost:
+            lines += _listed(
+                "**Not back in place - act on these:**",
+                [subscription for subscription, _ in outcome.lost],
+                outcome.logins,
+            )
+        if not outcome.dumped:
+            lines.append("**Abandoned:** the dump could not be delivered.")
+    else:
+        lines += _listed(
+            f"**Dry run.** Would repoint {len(outcome.repoint)}:",
+            outcome.repoint,
+            outcome.logins,
+        )
+        lines += ["", "Run it again with `confirm: True` to do it."]
+
+    if outcome.keep:
+        lines.append(f"{len(outcome.keep)} already current.")
+    if outcome.skip:
+        lines += _listed(
+            "Left alone, no route for the type:", outcome.skip, outcome.logins
+        )
+    if outcome.dumped:
+        lines.append(
+            "The full definition of every subscription is in the admin channel."
+        )
+
+    return _within_limit(lines)
+
+
+def _within_limit(lines: list[str]) -> str:
+    """The lines that fit, whole, and a pointer to the rest.
+
+    Slicing the joined text instead cuts mid-line, and the line most likely to
+    be cut is the last of the ones naming what is now missing -- which is the
+    one worth reading. Dropping whole lines keeps every line that survives
+    readable, and the dump has all of them anyway.
+    """
+    text = "\n".join(lines)
+    if len(text) <= _DISCORD_MESSAGE_LIMIT:
+        return text
+
+    more = "... and more. Every subscription is in the admin channel dump."
+    kept: list[str] = []
+    budget = _DISCORD_MESSAGE_LIMIT - len(more) - 1
+    for line in lines:
+        if sum(len(k) + 1 for k in kept) + len(line) > budget:
+            break
+        kept.append(line)
+    return "\n".join([*kept, more])
+
+
+async def _repoint(
+    subscription: Subscription, path: str, outcome: Outcome, logins: Mapping[str, str]
+) -> None:
+    """Move one subscription, or say precisely what is now missing.
+
+    The delete has to come first -- see the module docstring -- so a create that
+    fails afterwards leaves nothing behind. That is what ``lost`` records, and
+    why it is reported per subscription rather than only in the summary.
+    """
+    identity = describe(subscription, logins)
+    try:
+        await delete_subscription(subscription.id)
+    except HelixError as e:
+        # Nothing was destroyed: the old subscription is still whatever it was.
+        outcome.lost.append((subscription, f"not deleted, left as it was: {e}"))
+        await notify(
+            f"Could not delete {identity} while repointing it, so it still"
+            f" calls back on {subscription.transport.callback}: {e}",
+            key=f"migrate-delete:{subscription.id}",
+        )
+        return
+
+    try:
+        await create_subscription(
+            subscription.type,
+            subscription.version,
+            condition_of(subscription),
+            callback_url(path),
+        )
+    except HelixError as e:
+        outcome.lost.append((subscription, f"deleted, not recreated: {e}"))
+        await notify(
+            f"{identity} is now GONE: it was deleted and could not be recreated"
+            f" ({e}). Definition: version {subscription.version}, condition"
+            f" {json.dumps(condition_of(subscription))}.",
+            key=f"migrate-create:{subscription.id}",
+        )
+        return
+
+    outcome.migrated.append(subscription)
+
+
+async def migrate(routes: Mapping[str, str], *, confirm: bool) -> Outcome:
+    """Repoint every subscription this deployment has a route for.
+
+    A failed Helix listing raises, because a migration that cannot see the
+    subscriptions has nothing to work from. Everything after that point is
+    per-subscription: one that will not move must not abandon the ones behind it.
+    """
+    subscriptions = await get_subscriptions()
+    outcome = Outcome()
+    for subscription in subscriptions:
+        match decide(subscription, routes):
+            case Action.REPOINT:
+                outcome.repoint.append(subscription)
+            case Action.KEEP:
+                outcome.keep.append(subscription)
+            case Action.SKIP:
+                outcome.skip.append(subscription)
+
+    if not outcome.repoint:
+        return outcome
+
+    logins = await _logins(subscriptions)
+    outcome.logins = dict(logins)
+
+    # Every subscription rather than the ones about to move, and on a dry run as
+    # well as a real one: the dry run is how somebody gets this file before
+    # committing to the destruction, and after the delete it is the only record
+    # that a lost subscription existed at all.
+    outcome.dumped = await notify_file(
+        f"{'Repointing' if confirm else 'Dry run for'} "
+        f"{len(outcome.repoint)} EventSub subscription(s). This is every"
+        f" subscription as it stands, which is the only record of the ones that"
+        f" delete-then-create is about to put at risk.",
+        "eventsub-subscriptions.json",
+        render_dump(subscriptions, routes, logins),
+    )
+
+    if not confirm:
+        return outcome
+
+    if not outcome.dumped:
+        # Refusing is the whole safety property: a delete whose record did not
+        # land is one nobody can undo.
+        await notify(
+            "Migration abandoned before touching anything: the subscription dump"
+            " could not be delivered, and deleting without it is unrecoverable."
+        )
+        return outcome
+
+    for subscription in outcome.repoint:
+        await _repoint(subscription, routes[subscription.type], outcome, logins)
+
+    if outcome.lost:
+        await notify(
+            f"Migration finished with {len(outcome.lost)} subscription(s) not"
+            f" back in place:\n"
+            + "\n".join(
+                f"- {describe(subscription, logins)}: {reason}"
+                for subscription, reason in outcome.lost
+            )
+        )
+    return outcome

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -49,17 +49,28 @@ class Action(StrEnum):
 def decide(subscription: Subscription, routes: Mapping[str, str]) -> Action:
     """What to do with this subscription. Pure, and the whole rule.
 
-    KEEP is status-aware because a subscription Twitch disabled delivers nothing
-    however right its callback looks, and leaving one behind is the failure this
-    command exists to end. A disabled subscription on the correct callback is
-    still repointed, which recreates it enabled.
+    The callback decides, and the status deliberately does not. This used to
+    repoint anything not ``enabled`` even when its callback was already right,
+    on the reasoning that a disabled subscription delivers nothing whatever its
+    callback says. True, and not this command's problem: that reasoning bought a
+    delete-then-create on a subscription already pointing where it should.
+
+    Which is worse than doing nothing in every case it reaches.
+    ``webhook_callback_verification_pending`` is a few-second transient on the
+    way to ``enabled``, so catching one mid-verification destroys something that
+    was about to arrive by itself. ``authorization_revoked``, ``user_removed``
+    and ``moderator_removed`` are not things recreating repairs, so the delete
+    turns a subscription that is at least visible in ``get_subscriptions()`` into
+    one that is gone -- and six of the eight types cannot be recreated here.
+
+    A subscription that is on the right callback and still not delivering is
+    already ``undeliverable``, which ``recheck_subscriptions`` reports hourly.
+    That check owns the problem; this one owns the callback.
     """
     path = routes.get(subscription.type)
     if path is None:
         return Action.SKIP
-    if subscription.status == "enabled" and subscription.transport.callback == (
-        callback_url(path)
-    ):
+    if subscription.transport.callback == callback_url(path):
         return Action.KEEP
     return Action.REPOINT
 
@@ -72,9 +83,17 @@ class Outcome:
     keep: list[Subscription] = field(default_factory=list)
     skip: list[Subscription] = field(default_factory=list)
     migrated: list[Subscription] = field(default_factory=list)
-    # Subscriptions that are now gone: the delete landed and the create did not.
+    # Two failure modes, kept apart because they call for opposite responses and
+    # only one of them is an emergency. `stuck` did not move and is still
+    # whatever it was, on the old callback -- a retry is the whole remedy.
+    # `lost` is gone: the delete landed and the create did not, so for six of
+    # the eight types the dump is the only way back. Reporting them as one list
+    # made a working subscription and a destroyed one read identically.
+    stuck: list[tuple[Subscription, str]] = field(default_factory=list)
     lost: list[tuple[Subscription, str]] = field(default_factory=list)
     dumped: bool = False
+    # True when a confirmed run was already in flight, so this one did nothing.
+    busy: bool = False
     # Carried so the caller names people rather than ids, without asking Helix
     # the same question a second time.
     logins: dict[str, str] = field(default_factory=dict)
@@ -204,9 +223,32 @@ def _listed(
     return [heading, *(f"- {describe(s, logins)}" for s in subscriptions)]
 
 
+def _with_reasons(
+    heading: str,
+    failures: list[tuple[Subscription, str]],
+    logins: Mapping[str, str],
+) -> list[str]:
+    """A failure list that keeps its reasons.
+
+    The reason is the difference between a subscription somebody has to go and
+    recreate by hand and one they can leave alone, and dropping it made those
+    two read identically in the one message the operator sees first.
+    """
+    return [
+        heading,
+        *(f"- {describe(s, logins)}: {reason}" for s, reason in failures),
+    ]
+
+
 def summary(outcome: Outcome, *, confirm: bool) -> str:
     """What the pass found, and did. Rendered here rather than by the caller, so
     the thing that knows what an Outcome means is what says it out loud."""
+    if outcome.busy:
+        return (
+            "A confirmed migration is already running. This one did nothing --"
+            " two at once would race each other's deletes."
+        )
+
     if not outcome.repoint:
         left_alone = f", {len(outcome.skip)} left alone" if outcome.skip else ""
         return (
@@ -218,9 +260,15 @@ def summary(outcome: Outcome, *, confirm: bool) -> str:
     if confirm:
         lines.append(f"Repointed {len(outcome.migrated)}/{len(outcome.repoint)}.")
         if outcome.lost:
-            lines += _listed(
-                "**Not back in place - act on these:**",
-                [subscription for subscription, _ in outcome.lost],
+            lines += _with_reasons(
+                "**GONE - recreate these from the dump:**",
+                outcome.lost,
+                outcome.logins,
+            )
+        if outcome.stuck:
+            lines += _with_reasons(
+                "Not moved, still on the old callback - safe to retry:",
+                outcome.stuck,
                 outcome.logins,
             )
         if not outcome.dumped:
@@ -262,28 +310,66 @@ def _within_limit(lines: list[str]) -> str:
     more = "... and more. Every subscription is in the admin channel dump."
     kept: list[str] = []
     budget = _DISCORD_MESSAGE_LIMIT - len(more) - 1
+    used = 0
     for line in lines:
-        if sum(len(k) + 1 for k in kept) + len(line) > budget:
+        if used + len(line) > budget:
             break
         kept.append(line)
+        used += len(line) + 1
     return "\n".join([*kept, more])
+
+
+async def _exists_at(subscription: Subscription, callback: str) -> bool:
+    """Whether Twitch already has this subscription on this callback.
+
+    Asked only after a 409, and the reason it has to be asked is that
+    ``create_subscription`` is ``repeatable``. A POST whose reply is lost is
+    re-sent, and Twitch answers the retry with a 409 because the first attempt
+    did create it -- so the 409 says the subscription exists at least as often as
+    it says somebody else got there first. Reporting it as destroyed would send
+    somebody to recreate, by hand, a subscription that is already in place, and
+    for the six types provisioned outside this repo that attempt 409s too.
+
+    A lookup that itself fails answers False: unproven is not the same as
+    present, and over-reporting a loss costs an unnecessary check while
+    under-reporting one costs a subscription nobody knows is missing.
+
+    ``version`` is compared too, though Twitch documents its 409 as being about
+    the type and condition alone. If that is the whole key the clause is
+    redundant and costs nothing; if version is part of it, leaving the clause out
+    would let a subscription of another version for the same type and condition
+    be mistaken for the one just recreated. Redundant beats wrong, and a stricter
+    match errs toward reporting a loss, which is the direction chosen above.
+    """
+    try:
+        return any(
+            other.type == subscription.type
+            and other.version == subscription.version
+            and other.condition == subscription.condition
+            and other.transport.callback == callback
+            for other in await get_subscriptions()
+        )
+    except HelixError:
+        return False
 
 
 async def _repoint(
     subscription: Subscription, path: str, outcome: Outcome, logins: Mapping[str, str]
 ) -> None:
-    """Move one subscription, or say precisely what is now missing.
+    """Move one subscription, or say precisely what became of it.
 
     The delete has to come first -- see the module docstring -- so a create that
-    fails afterwards leaves nothing behind. That is what ``lost`` records, and
-    why it is reported per subscription rather than only in the summary.
+    fails afterwards leaves nothing behind. ``lost`` is that case and only that
+    case; a delete that failed leaves the subscription untouched and goes to
+    ``stuck``, because the two need opposite things done about them.
     """
     identity = describe(subscription, logins)
+    callback = callback_url(path)
     try:
         await delete_subscription(subscription.id)
     except HelixError as e:
         # Nothing was destroyed: the old subscription is still whatever it was.
-        outcome.lost.append((subscription, f"not deleted, left as it was: {e}"))
+        outcome.stuck.append((subscription, f"delete failed, untouched: {e}"))
         await notify(
             f"Could not delete {identity} while repointing it, so it still"
             f" calls back on {subscription.transport.callback}: {e}",
@@ -296,9 +382,18 @@ async def _repoint(
             subscription.type,
             subscription.version,
             condition_of(subscription),
-            callback_url(path),
+            callback,
         )
     except HelixError as e:
+        if e.status == 409 and await _exists_at(subscription, callback):
+            outcome.migrated.append(subscription)
+            logger.info(
+                "409 on recreating %s, and it is present on %s: a retried POST"
+                " whose first attempt had already landed",
+                subscription.type,
+                callback,
+            )
+            return
         outcome.lost.append((subscription, f"deleted, not recreated: {e}"))
         await notify(
             f"{identity} is now GONE: it was deleted and could not be recreated"
@@ -317,7 +412,38 @@ async def migrate(routes: Mapping[str, str], *, confirm: bool) -> Outcome:
     A failed Helix listing raises, because a migration that cannot see the
     subscriptions has nothing to work from. Everything after that point is
     per-subscription: one that will not move must not abandon the ones behind it.
+
+    A second confirmed run refuses while one is in flight. Two of them would
+    interleave deletes and creates over the same subscriptions, where the loser
+    of a delete race is reported untouched when it was destroyed, and the loser
+    of a create race gets a 409 that no longer means what it usually does.
+    Refusing rather than queueing, because a run that waits and then finds
+    nothing left to do looks exactly like one that was not needed.
+
+    A dry run is not guarded: it changes nothing, so two of them cost two
+    listings.
     """
+    global _confirming
+    if confirm and _confirming:
+        return Outcome(busy=True)
+    if confirm:
+        # Taken here, with no await between the check above and this line, for
+        # the reason controller/twitch.py _claim is one step: an await in the
+        # gap would let two runs both pass a check that only looked.
+        _confirming = True
+    try:
+        return await _migrate(routes, confirm=confirm)
+    finally:
+        if confirm:
+            _confirming = False
+
+
+# Whether a confirmed migration is mid-flight. A plain flag rather than a lock:
+# what is wanted is refusal, and asyncio.Lock queues.
+_confirming = False
+
+
+async def _migrate(routes: Mapping[str, str], *, confirm: bool) -> Outcome:
     subscriptions = await get_subscriptions()
     outcome = Outcome()
     for subscription in subscriptions:
@@ -365,11 +491,22 @@ async def migrate(routes: Mapping[str, str], *, confirm: bool) -> Outcome:
 
     if outcome.lost:
         await notify(
-            f"Migration finished with {len(outcome.lost)} subscription(s) not"
-            f" back in place:\n"
+            f"Migration destroyed {len(outcome.lost)} subscription(s) it could"
+            f" not recreate. Recreate these from the dump:\n"
             + "\n".join(
                 f"- {describe(subscription, logins)}: {reason}"
                 for subscription, reason in outcome.lost
+            )
+        )
+    if outcome.stuck:
+        # Separately, and not as an emergency: these are still delivering on the
+        # old callback, so the remedy is running the command again.
+        await notify(
+            f"Migration left {len(outcome.stuck)} subscription(s) on the old"
+            f" callback, untouched. Re-running moves them:\n"
+            + "\n".join(
+                f"- {describe(subscription, logins)}: {reason}"
+                for subscription, reason in outcome.stuck
             )
         )
     return outcome

--- a/uv.lock
+++ b/uv.lock
@@ -83,16 +83,16 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.19.2"
+version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/aa/02910bdb8e2f1444f6654d5b296cd827d126f82209050ee7b1000f92ac4b/alembic-1.20.0.tar.gz", hash = "sha256:db505480647bc60386c5369402f4a57a506b7539c9e9ef5e270d45cbbe4939bf", size = 2093272, upload-time = "2026-09-11T19:09:11.126Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/27/78a89b55b0904d222183164e079b4ca56208e94eff1d35ad1f1ad5be9b06/alembic-1.20.0-py3-none-any.whl", hash = "sha256:77eb101048d95f982c0353e9233404889dcd7a6fc244c107836c0e2fc9cf7d9d", size = 268719, upload-time = "2026-09-11T19:09:12.88Z" },
 ]
 
 [[package]]
@@ -912,7 +912,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "alembic", specifier = ">=1.19.2" },
+    { name = "alembic", specifier = ">=1.20.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "discord", specifier = ">=2.3.2" },
     { name = "fastapi", specifier = ">=0.141.1" },


### PR DESCRIPTION
Closes #43.

Moving the public host off the loclx tunnel orphans **every** EventSub subscription at once, and six of the eight types cannot be created from this repo at all. `/migrate-subscriptions` is that gap closed.

## What it does

Owner-only, dry-run by default. It works off the live `get_subscriptions()` list and never a fixed one: there are eight subscription *types* but `6 + 2N` *subscriptions*, since `stream.online`/`stream.offline` exist once per subscribed broadcaster and nothing in this repo knows what `N` is — that list lives only in Twitch. Anything seeded from a list written here would silently leave every promo broadcaster behind.

Twitch's uniqueness key is the type and the condition **alone, not the transport**, so the same event at a new callback is a 409 and repointing has to be delete-then-create. Everything below follows from that being destructive and unreplayable:

- The complete definition of every subscription goes to the admin channel as a file **before anything is deleted**, and on the dry run too, so the record exists before the run that needs it. Each id is resolved to a login, because a subscription stores an id while `/subscribe` takes a name.
- A dump that could not be delivered **abandons the run** rather than deleting without it.
- A failure is reported per subscription and does not abandon the ones behind it.
- A type with no route is reported and **left alone** — deleting it would destroy something created deliberately elsewhere.

## Commits

| Commit | What |
| --- | --- |
| `391f3d2` | `SubscriptionCondition` keeps undeclared keys — a condition is now round-tripped, so a `reward_id` must not vanish |
| `dd52985` | `WEBHOOK_PATHS` derived from the `_route` table via each model's `Literal`, not a ninth list |
| `905a528` | `errors.notify_file` — a notice carrying a record too long for a 1900-char message |
| `2710b23` | Helix can create/delete any subscription type, not just a stream pair; `version` travels |
| `9e8fb15` | The command itself, plus `AGENTS.md` |
| `eeeb476` | Four findings from an adversarial review (below) |
| `3014bc2` | **Unrelated:** alembic 1.19.2 → 1.20.0, its own commit |

## What the adversarial review caught

Worth reading, because two were real bugs in the first pass:

1. **A 409 on the recreate was reported as GONE when the subscription existed.** `create_subscription` is `repeatable`, so a POST whose reply was lost is re-sent and Twitch answers the retry 409 *because the first attempt created it*. `_exists_at` now asks Helix before anything is called lost. Reproduced with a client that dies mid-reply then returns 409.
2. **A failed delete and a failed create were reported as one thing.** Both went into one list whose reasons the summary then discarded, so a subscription still delivering on the old callback and one that had been destroyed rendered identically — in the reply an operator reads first. Now `stuck` and `lost`, two headings, reasons carried through.
3. **Nothing stopped two confirmed runs racing.** A plain module flag now refuses the second; a lock would queue, and refusal is what is wanted.
4. **`decide()` destroyed a correct-callback subscription that was merely not `enabled`.** `webhook_callback_verification_pending` is a seconds-long transient, so that destroyed subscriptions about to arrive by themselves. The status condition is removed, and `AGENTS.md` records that its original justification was wrong.

## Verification

**No test suite**, so this is not tested in the repo's sense. The four checks in `AGENTS.md` pass in order (sourcery `--fix`, sourcery `--check`, ruff format, ruff check, pyright), and `verity analyze` was clean while uncommitted — PASS, quality 8.2, security 10/10.

Behaviour was exercised by a throwaway harness against a faked `get_subscriptions()`, covering: two `stream.online`/`stream.offline` pairs both moved (the `N > 1` case), an unrouted type left alone, an already-correct subscription untouched, a `reward_id` outside the declared condition keys surviving the round-trip, `version` copied rather than hardcoded, a failed recreate named without abandoning the rest, a re-run sending nothing, and one case per review finding — including a 409 whose subscription is genuinely **absent**, which still reports GONE, proving the fix did not simply swallow every 409.

The real cutover cannot be rehearsed locally: EventSub cannot reach `localhost`.

## Reviewer notes

- `3014bc2` is an alembic bump that arrived in the working tree mid-branch. It is deliberately its own commit and touches nothing else; verified by rendering the whole revision chain offline under 1.20.0 (`PYTHONIOENCODING=utf-8 uv run alembic upgrade head --sql`, all eight revisions, exit 0). Drop it from the merge if you would rather it went separately.
- `services/twitch/migrate.py` is now large enough that Verity's reviewer truncated it on a later run (`file-middle-truncated-300-lines`). It was reviewed in full at its own commit, but be aware a future run over that file may cover less than it appears to.
- The human steps for the cutover — redirect URIs, `APP_URL`, the domain's target port, when to run it — are not in this PR. They are written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a safe, owner-controlled migration workflow to repoint live Twitch EventSub subscriptions after a public URL change.

New Features:
- Add an owner-only `/migrate-subscriptions` command that discovers live EventSub subscriptions and repoints routed subscriptions to the deployment’s current public URL.
- Provide dry-run migration reports and pre-change JSON dumps containing complete subscription definitions for recovery.
- Support recreating all routed EventSub subscription types with their original versions and conditions, including previously undeclared condition fields.

Bug Fixes:
- Prevent destructive migrations for subscriptions already using the current callback regardless of transient or non-enabled status.
- Handle retry-induced recreate conflicts by verifying whether the subscription already exists before reporting it as lost.
- Distinguish failed deletes from failed recreates in migration results and preserve actionable failure reasons.
- Leave subscription types without a local webhook route untouched.

Enhancements:
- Derive webhook subscription routes from registered event models to prevent route metadata drift.
- Prevent concurrent confirmed migrations from racing each other.
- Extend notification delivery to support unfiltered file attachments for recovery records.
- Generalize EventSub callback URL, creation, and deletion helpers beyond stream subscriptions.

Build:
- Raise the minimum Alembic dependency to 1.20.0.

Documentation:
- Document migration safety rules, live subscription discovery, dry-run behavior, recovery dumps, and operational failure handling.

Tests:
- Validate migration behavior with a throwaway harness covering multiple broadcasters, unrouted and current subscriptions, condition round-tripping, version preservation, partial failures, reruns, and concurrency/retry edge cases.