### PR TITLE
Report the whole notice instead of slicing it, and key the unusable-id notices on their values

### DIFF
--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from datetime import datetime
 from typing import ClassVar
 
@@ -24,11 +25,24 @@ _ANNOUNCE_GRACE_SECONDS = 24 * 60 * 60
 
 
 def undeliverable_summary(broken: dict[str, str]) -> str:
-    detail = "\n".join(f"- {identity}: {reason}" for identity, reason in broken.items())
+    """Every subscription that will not deliver, counted by reason before listed.
+
+    The counts and the advice come first because they are what survives being
+    cut, and one reason covering every subscription is the whole diagnosis: a
+    public URL that moved makes all of them undeliverable for the same reason,
+    which as a line each was 97 copies of one sentence and five times what a
+    Discord message holds. The per-subscription detail still follows, for the
+    cases where which one matters.
+    """
+    counts = Counter(broken.values())
+    headline = "\n".join(
+        f"- {count} {reason}" for reason, count in counts.most_common()
+    )
+    detail = "\n".join(f"  {identity}: {reason}" for identity, reason in broken.items())
     return (
-        f"{len(broken)} Twitch subscription(s) will not deliver:\n{detail}\n"
+        f"{len(broken)} Twitch subscription(s) will not deliver:\n{headline}\n"
         "/subscribe replaces the stream.online and stream.offline pair; the"
-        " rest are registered outside the bot."
+        f" rest are registered outside the bot.\n{detail}"
     )
 
 

--- a/errors.py
+++ b/errors.py
@@ -27,8 +27,13 @@ logger = logging.getLogger(__name__)
 _ADMIN_CHANNEL = "bot_admin"
 
 # Discord rejects a message over 2000 characters, and a rejected report is a
-# lost one. The traceback goes as a file, so only the summary is at risk.
+# lost one. A notice whose length follows how much went wrong reaches this: 97
+# undeliverable subscriptions is one line each, several times over the limit.
 _MAX_CONTENT = 1900
+
+# What replaces the lines that did not fit. Named so the reader knows the notice
+# was cut rather than that it ended there, which is what a bare slice looked like.
+_OVERFLOW_NOTE = "... the rest is attached."
 
 # How long one delivered message stands in for its own repeats.
 _WINDOW_SECONDS = 15 * 60
@@ -188,6 +193,26 @@ def notify_soon(text: str, *, key: str | None = None) -> None:
     fire_and_forget(notify(text, key=key), name="notify")
 
 
+def _shortened(text: str) -> str:
+    """The whole lines that fit, and a note saying the rest is attached.
+
+    Whole lines because the tail of a notice is where its detail is, and a cut
+    mid-line reads as the notice ending rather than as being truncated -- which
+    is how a list of 97 undeliverable subscriptions appeared to stop at 30 for
+    no reason. A single line longer than the budget yields the note alone, since
+    there is nothing whole to keep.
+    """
+    budget = _MAX_CONTENT - len(_OVERFLOW_NOTE) - 1
+    kept: list[str] = []
+    used = 0
+    for line in text.split("\n"):
+        if used + len(line) > budget:
+            break
+        kept.append(line)
+        used += len(line) + 1
+    return "\n".join([*kept, _OVERFLOW_NOTE])
+
+
 async def _deliver(text: str, attachment: tuple[str, str] | None) -> bool:
     # Deferred: importing services at module scope runs the whole package, and
     # main.py reports cog-load failures before any of it is up.
@@ -202,26 +227,38 @@ async def _deliver(text: str, attachment: tuple[str, str] | None) -> bool:
 
     from services.send import send_message
 
-    file = None
-    if attachment is not None:
-        filename, content = attachment
-        file = discord.File(io.BytesIO(content.encode("utf-8")), filename=filename)
-    # quiet: send_message announces a channel it cannot resolve, and announcing
-    # this one goes through here again.
     if _undelivered:
-        # Leading, because the tail is what gets truncated. Prepended here rather
-        # than at the call site so every path through the admin channel carries
-        # it, and cleared only once something has actually arrived.
+        # Leading, because the tail is what gets cut. Prepended here rather than
+        # at the call site so every path through the admin channel carries it,
+        # and cleared only once something has actually arrived. Before the
+        # overflow check below, so the prefix cannot push the result back over.
         text = (
             f"[{_undelivered} message(s) reached nobody while this channel was"
             f" unreachable]\n{text}"
         )
 
+    if len(text) > _MAX_CONTENT:
+        # The whole notice goes as a file, unless something already claimed the
+        # one attachment a message can carry -- a report's traceback, which is
+        # worth more than its summary's tail. Nothing is discarded silently
+        # either way: losing a report is the one thing this module exists to
+        # prevent, and a slice at 1900 characters was doing exactly that.
+        if attachment is None:
+            attachment = ("notice.txt", text)
+        text = _shortened(text)
+
+    file = None
+    if attachment is not None:
+        filename, content = attachment
+        file = discord.File(io.BytesIO(content.encode("utf-8")), filename=filename)
+
     # Counted before the attempt, not after it: send_message raises on a
     # channel it resolved but could not post to, and that reached nobody too.
+    # quiet: send_message announces a channel it cannot resolve, and announcing
+    # this one goes through here again.
     _undelivered += 1
     sent = await send_message(
-        text[:_MAX_CONTENT],
+        text,
         config.channel(_ADMIN_CHANNEL),
         file=file,
         quiet=True,

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -186,6 +186,12 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
     a *different* set inside the fifteen-minute window, in the one path that
     exists to make these visible -- and the run that follows a dry run is well
     inside it.
+
+    ``json.dumps`` rather than joining on a comma, because ``unusable`` is by
+    construction whatever failed the digit test, so a value holding a comma is
+    the shape most likely to be in it -- and joining made ``['a,b']`` and
+    ``['a', 'b']`` the same key, which is the same suppression bug again by a
+    narrower route.
     """
     ids = _condition_ids(subscriptions)
     usable = [value for value in ids if _usable(value)]
@@ -195,7 +201,7 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
             f" user id, so they were left out of the login lookup:"
             f" {_some(unusable)}."
             f" The dump still carries every condition in full.",
-            key=f"migrate-unusable-ids:{','.join(unusable)}",
+            key=f"migrate-unusable-ids:{json.dumps(unusable)}",
         )
 
     if not usable:
@@ -208,7 +214,7 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
             f" subscription dump, so it names ids only: {e}."
             f" The ids sent were: {_some(usable)}."
             f" A 400 here means one of them is a shape Helix will not take.",
-            key=f"migrate-dump-logins:{','.join(usable)}",
+            key=f"migrate-dump-logins:{json.dumps(usable)}",
         )
         return {}
 

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -134,13 +134,36 @@ def _condition_ids(subscriptions: list[Subscription]) -> list[str]:
 
 
 def _usable(value: str) -> bool:
-    """Whether Helix will accept this as a user id.
+    """Whether this could be a Twitch user id at all.
 
-    A Twitch user id is a run of ASCII digits. ``isascii`` as well as
-    ``isdigit`` because the latter is true of Arabic-Indic digits and of
-    superscripts, neither of which Helix parses as a number.
+    A run of ASCII digits. ``isascii`` as well as ``isdigit`` because the latter
+    is true of Arabic-Indic digits and of superscripts, neither of which Helix
+    parses as a number.
+
+    Necessary and not sufficient, deliberately: what Helix's own validator
+    accepts is not published, so a value that is all digits and still refused
+    would pass here. Bounding the length would be inventing a rule about
+    somebody else's id format, and rejecting a real id is worse than sending one
+    Twitch declines -- which is why the failure below names what it sent.
     """
     return value.isascii() and value.isdigit()
+
+
+# How many values a notice names before it stops and says how many are left. The
+# lists here are as long as the subscription count and the dump carries all of
+# them, so the message only has to be enough to start looking.
+_NAMED_LIMIT = 10
+
+
+def _some(values: list[str]) -> str:
+    """The first few values, saying how many were not named.
+
+    The remainder is stated rather than implied: a count that does not match the
+    list reads as a bug in the report rather than a cap on it.
+    """
+    shown = ", ".join(repr(value) for value in values[:_NAMED_LIMIT])
+    rest = len(values) - _NAMED_LIMIT
+    return f"{shown} and {rest} more" if rest > 0 else shown
 
 
 async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
@@ -152,10 +175,17 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
 
     Anything that cannot be a user id is dropped before the call rather than
     sent. Helix answers one malformed identifier with a 400 for the whole
-    request -- it ignores ids that merely do not exist, so a 400 is always about
-    the shape of one of them -- and that cost every login in the batch, not just
-    the bad one. Reported rather than dropped quietly: a condition holding
-    something that is not an id is worth a person knowing about.
+    request, and it ignores ids that merely do not exist, so a 400 from that
+    endpoint is about the shape of something rather than a deleted account --
+    and it cost every login in the batch, not just the bad one. Both notices
+    name the values involved, because the filter cannot be complete: a value
+    Helix refuses for a reason not visible from here has to leave behind enough
+    for somebody to find it.
+
+    Each key carries the values it is about. Keying on the notice alone held back
+    a *different* set inside the fifteen-minute window, in the one path that
+    exists to make these visible -- and the run that follows a dry run is well
+    inside it.
     """
     ids = _condition_ids(subscriptions)
     usable = [value for value in ids if _usable(value)]
@@ -163,9 +193,9 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
         await notify(
             f"{len(unusable)} subscription condition value(s) cannot be a Twitch"
             f" user id, so they were left out of the login lookup:"
-            f" {', '.join(repr(value) for value in unusable[:10])}."
+            f" {_some(unusable)}."
             f" The dump still carries every condition in full.",
-            key="migrate-unusable-ids",
+            key=f"migrate-unusable-ids:{','.join(unusable)}",
         )
 
     if not usable:
@@ -175,8 +205,10 @@ async def _logins(subscriptions: list[Subscription]) -> dict[str, str]:
     except HelixError as e:
         await notify(
             f"Could not resolve {len(usable)} Twitch id(s) to logins for the"
-            f" subscription dump, so it names ids only: {e}",
-            key="migrate-dump-logins",
+            f" subscription dump, so it names ids only: {e}."
+            f" The ids sent were: {_some(usable)}."
+            f" A 400 here means one of them is a shape Helix will not take.",
+            key=f"migrate-dump-logins:{','.join(usable)}",
         )
         return {}
 


### PR DESCRIPTION
Two reporting defects found by running `/migrate-subscriptions` for real, on a deployment with 97 subscriptions. Neither changes what the migration *does* — both are about it being able to tell you what happened.

Builds on `43cd071`, already on master.

## 1. An over-long notice was sliced at 1900 characters

**Symptom:** 97 undeliverable subscriptions produced a 9,813-character notice. The admin channel showed roughly the first twenty lines, with nothing saying the other seventy-seven existed.

`errors._deliver` ended in `send_message(text[:_MAX_CONTENT])` — a blunt slice, in the one module whose stated purpose is that a report is never lost, cutting mid-line so the notice appeared to *end* rather than to have been truncated. Every caller of `notify`/`report` was exposed; `undeliverable_summary` is simply the first whose length follows how much went wrong.

Now: whole lines that fit, a note saying the rest is attached, and the full text as `notice.txt`. A `report` keeps `traceback.txt` instead — one message carries one attachment and a traceback is worth more than a summary's tail — and that summary is still cut on a line boundary. A notice that fits is untouched and unattached.

The `[N message(s) reached nobody]` prefix moved *above* the overflow check, so it cannot push an already-fitted message back over the limit.

**Also made the message worth reading.** With 97 subscriptions sharing one reason, the old form was 97 copies of the same sentence and the visible twenty told you nothing. `undeliverable_summary` now counts by reason first, so what survives a cut is the whole diagnosis:

```
97 Twitch subscription(s) will not deliver:
- 97 calling back on https://oldtunnel.loclx.io/webhook/twitch
/subscribe replaces the stream.online and stream.offline pair; …
```

A mixed set gets per-reason counts, and the detail still names which subscription had which reason.

## 2. The unusable-id notice lost a different set of values

Found by an adversarial review of `43cd071`, and **confirmed by reproducing it**: a static `notify` key meant `errors.py`'s fifteen-minute window treated a *different* set of unusable values as a repeat. A dry run reporting value `X`, then the confirmed run that follows — which `summary()` explicitly tells you to do, well inside that window — reporting value `Y`, delivered only `X`. `Y` was counted and discarded, and `notify` still returned `True`.

That is precisely the failure `AGENTS.md` describes: the varying detail was left out of the key, so nothing was held back — it was lost. Both keys now carry their values, matching `migrate-delete:` and `migrate-create:` two functions away.

Also: the ten-value cap said nothing about itself, so a notice reading "15 value(s) … : a, b, … j." made the reader do arithmetic to discover it was truncated, where `_within_limit` in the same module already says "… and more". `_some()` handles both notices.

## One thing I did not take from the review

The reviewer wanted a **length bound** on `_usable` (Twitch ids being "well under 15 digits"). Declined: that invents a rule about someone else's id format, and rejecting a real id is worse than sending one Twitch declines. `_usable` is now documented as *necessary and not sufficient*, and the residual gap is closed by diagnosability instead — the 400 path names the ids it sent, so a recurrence with an all-digits-but-invalid value leaves a trail rather than nothing.

The review was also right that `43cd071`'s message overclaimed its diagnosis as "certain" when nothing had ruled that case out. That commit is on master and unrewritable, so `22610b6` records the correction.

## Verification

**No test suite**, so this is not tested in the repo's sense. The four checks in `AGENTS.md` pass in order, and `verity analyze` was clean while uncommitted (PASS, quality 7.8).

Behaviour was exercised by throwaway harnesses against the real shapes:

- **97 identical reasons, 9,813 characters** — message under the limit, every kept line whole and present in the original, attachment byte-identical to the full notice, count line and advice both surviving the cut.
- **The old static key reproduced**, delivering 1 of 2 notices, then the keyed version delivering both.
- Mixed reasons; a short notice left untouched and unattached; `report`'s traceback taking precedence; `_some` at exactly the limit and one over.

## Reviewer note

`services/twitch/migrate.py` is over the 400-line file-length standard and Verity's reviewer has truncated it on some runs, so a clean report over that file may cover less than it appears to. Tracked in #47, deliberately not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve migration reporting so long notices and varying unusable-ID failures remain complete, distinguishable, and actionable.

Bug Fixes:
- Preserve complete over-limit admin notices through attachments while retaining readable, line-bounded summaries.
- Prevent unusable-ID notifications from suppressing distinct value sets and make truncation explicit.
- Improve migration diagnostics by grouping undeliverable subscriptions by reason and reporting IDs involved in lookup failures.

Enhancements:
- Make migration notices more actionable by prioritizing aggregate diagnoses while retaining per-subscription details.