### PR TITLE
Drop empty condition values so a raid recreate is not refused after its delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,19 @@ Twitch adds — would otherwise be dropped in silence and recreate a subscriptio
 of the rule for EventSub payload models above, and for the opposite reason: those
 are read, this one is written back.
 
+**What the model keeps and what the recreate sends are different sets, and the
+difference is load-bearing.** `condition_of` drops every value that is `""`.
+Twitch answers with `""` for the unset half of a `channel.raid` condition — both
+directions are subscribed, so both arrive that way — and its create endpoint says
+of that pair: *"Set either the from_broadcaster_user_id or to_broadcaster_user_id
+condition parameter but not both. If you pass both parameters, the subscription
+request fails."* A faithful round-trip therefore deletes both raid subscriptions
+and recreates neither, on a type provisioned outside this repo that nothing here
+can rebuild. Dropping `""` is not lossy: it is how Twitch says *not set* on the
+way out and absence is how it requires the same thing on the way in. Compared
+against `""` and not tested for falsity, so a `0` or `False` Twitch chose to send
+in an undeclared key survives. **Do not make this round-trip faithful again.**
+
 **`WEBHOOK_PATHS` is derived from the `_route` table, not written beside it.**
 `controller/twitch.py` builds it as the routes register, reading each type off the
 `Literal` its model already declares — a ninth list of the eight types is one more

--- a/models/twitch_api_responses/subscription.py
+++ b/models/twitch_api_responses/subscription.py
@@ -10,6 +10,12 @@ class SubscriptionCondition(BaseModel):
     # rest of the code read one by name; anything Twitch adds -- a reward_id on a
     # redemption, say -- would otherwise vanish silently on the way through and
     # recreate a subscription broader than the one it replaced.
+    #
+    # What this model keeps and what the recreate sends are not the same set:
+    # migrate.condition_of drops any value that is "", because Twitch returns ""
+    # for the unset half of a channel.raid condition and refuses a create that
+    # carries both halves. Making that round-trip faithful again would delete
+    # both raid subscriptions and fail to recreate either.
     model_config = ConfigDict(extra="allow")
 
     broadcaster_user_id: str | None = None

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -242,11 +242,18 @@ def render_dump(
     routes: Mapping[str, str],
     logins: Mapping[str, str],
 ) -> str:
-    """The complete definition of every subscription, as JSON somebody can act on.
+    """Every subscription as JSON somebody can act on, not as Twitch phrased it.
 
-    Everything needed to recreate one by hand is here -- type, version, the full
+    Everything needed to recreate one by hand is here -- type, version,
     condition, and the login behind each id -- because after the delete this is
     the only record that it existed.
+
+    The condition is ``condition_of``'s, so a value Twitch sent as ``""`` is
+    absent here. That is the difference between a transcript and something
+    somebody can act on: pasting the raid condition back as Twitch phrased it is
+    refused, and this file exists to be pasted back. ``callback_now`` and
+    ``callback_after`` are likewise the migration's own reading rather than
+    fields Twitch returns.
     """
     return json.dumps(
         [

--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -110,12 +110,30 @@ _CONDITION_ID_FIELDS = (
 
 
 def condition_of(subscription: Subscription) -> dict[str, Any]:
-    """The condition as Twitch sent it, including keys the model does not declare.
+    """The condition as Twitch sent it, minus the keys it sent empty.
 
     ``exclude_none`` rather than a field list: the five declared keys default to
     None and only some are set per type, while extras carry no default at all.
+
+    The empty strings go for a harder reason than tidiness. Twitch answers with
+    ``""`` for the half of a ``channel.raid`` condition that is not set, and of
+    that pair its create endpoint says: "Set either the from_broadcaster_user_id
+    or to_broadcaster_user_id condition parameter but not both. If you pass both
+    parameters, the subscription request fails." Round-tripping the ``""`` back
+    therefore fails every raid recreate -- *after* its delete, which is the one
+    unrecoverable outcome this module has, on one of the six types nothing here
+    can rebuild.
+
+    Dropping it is not lossy: ``""`` is how Twitch says "not set" on the way out
+    and absence is how it requires the same thing on the way in. Compared against
+    ``""`` rather than tested for falsity, because ``0`` and ``False`` in an
+    undeclared key are values Twitch chose to send and are not this to decide.
     """
-    return subscription.condition.model_dump(exclude_none=True)
+    return {
+        key: value
+        for key, value in subscription.condition.model_dump(exclude_none=True).items()
+        if value != ""
+    }
 
 
 def _condition_ids(subscriptions: list[Subscription]) -> list[str]:


### PR DESCRIPTION
> **This one is urgent.** As it stands on master, running `/migrate-subscriptions confirm: True` would permanently destroy both `channel.raid` subscriptions. Do not run it until this is merged and deployed.

Found by reading a real dump of 97 subscriptions from a production dry run, not by review.

## What Twitch actually sends

Twitch answers with `""` for the half of a `channel.raid` condition that is not set. Both directions are subscribed, so both appear:

```json
{ "to_broadcaster_user_id": "422325043", "from_broadcaster_user_id": ""         }
{ "to_broadcaster_user_id": "",          "from_broadcaster_user_id": "422325043" }
```

`condition_of` used `exclude_none` only, so `""` is not `None` and survived into the **recreate**. Twitch's create endpoint is explicit about that pair:

> Set either the `from_broadcaster_user_id` or `to_broadcaster_user_id` condition parameter but not both. **If you pass both parameters, the subscription request fails.**

So both raid recreates would have failed — *after* their deletes, because Twitch's uniqueness key forces delete-then-create. `channel.raid` is one of the six types provisioned outside this repo, so nothing here could rebuild them: incoming and outgoing raid handling gone permanently, taking the autoshoutout-on-raid path with them.

**The dry run could not have warned about this.** It reported the condition it intended to send, and that condition looked exactly like the one Twitch had — because it was.

## The fix

`condition_of` drops keys whose value is `""`. Not lossy: `""` is how Twitch says "not set" on the way out, and absence is how it requires the same thing on the way in.

Compared against `""` rather than tested for falsity, because `0` and `False` in an undeclared key are values Twitch chose to send and are not this function's to discard.

## This also explains the empty string in the login lookup

The `''` that 400'd a batch of 47 logins (fixed in #48) was never junk in a condition field. It is these two raid subscriptions being entirely normal, deduplicated by the id set into a single `""`. That fix stopped it reaching Helix; this one stops it reaching a `POST`.

## Verification

**No test suite.** The four checks in `AGENTS.md` pass in order against the rebased tree.

Exercised against the three real conditions from the production dump that carry an empty value — both raids and the redemption whose `reward_id` is `""`:

```
incoming raid  -> {'to_broadcaster_user_id': '422325043'}
outgoing raid  -> {'from_broadcaster_user_id': '422325043'}
redemption     -> {'broadcaster_user_id': '422325043'}
a real reward_id survives
0 and False are kept; only '' is dropped
```

Plus the four existing harnesses from #46 and #48, all still passing.

## Note on the gate

The pre-commit hook gated this change at its pre-rebase SHA (`543e861`); the rebase replayed it as `d3f4ee9` with identical content. The four checks above were re-run against the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Drop empty condition values from subscription recreations so Twitch accepts channel raid migrations without losing subscriptions after deletion.

Bug Fixes:
- Prevent subscription migration from sending empty condition values that cause Twitch to reject channel raid recreates after the original subscriptions have been deleted.

Enhancements:
- Make rendered migration dumps actionable by omitting condition values Twitch represents as unset while preserving meaningful falsey values such as 0 and False.
- Document the distinction between preserving model fields and producing valid recreation conditions for Twitch.