### PR TITLE
Fix: empty raid condition half also leaked into login lookup and describe

### DIFF
--- a/services/twitch/migrate.py
+++ b/services/twitch/migrate.py
@@ -109,6 +109,30 @@ _CONDITION_ID_FIELDS = (
 )
 
 
+def _named_ids(subscription: Subscription) -> list[tuple[str, str]]:
+    """Every (label, value) an id field in this condition actually names.
+
+    The one place that reads ``_CONDITION_ID_FIELDS`` off a live condition, so
+    that filtering what counts as "named" only has to be right once. A field
+    Twitch left as ``""`` -- its way of saying "not set" on the unused half of a
+    ``channel.raid`` condition -- is skipped here for the same reason
+    ``condition_of`` drops it from the recreate: a value that names nobody is
+    not a value to look up, print, or resolve to a login.
+
+    Before this existed, three call sites read the raw attribute themselves and
+    only one of them remembered to check for ``""``. The other two put an empty
+    login lookup through Helix every run and printed "to broadcaster " with
+    nothing after it -- correct by the field's own logic, since ``""`` really is
+    what Twitch sent, and wrong by every reader's, since it never named anyone.
+    """
+    return [
+        (label, value)
+        for name, label in _CONDITION_ID_FIELDS
+        if isinstance(value := getattr(subscription.condition, name, None), str)
+        and value != ""
+    ]
+
+
 def condition_of(subscription: Subscription) -> dict[str, Any]:
     """The condition as Twitch sent it, minus the keys it sent empty.
 
@@ -137,16 +161,17 @@ def condition_of(subscription: Subscription) -> dict[str, Any]:
 
 
 def _condition_ids(subscriptions: list[Subscription]) -> list[str]:
-    """Every distinct value these conditions carry in an id field.
+    """Every distinct value these conditions name in an id field.
 
     Not necessarily an id: what a condition holds is Twitch's to decide, and
-    ``_usable`` is what decides whether it can be looked up.
+    ``_usable`` is what decides whether it can be looked up. ``""`` is already
+    excluded by ``_named_ids`` -- it is not a value anybody sent to be resolved,
+    it is Twitch declining to fill in the other half of a raid condition, and a
+    lookup for it produced a false "cannot be a Twitch user id" notice on every
+    run that had one.
     """
     ids = {
-        value
-        for subscription in subscriptions
-        for name, _ in _CONDITION_ID_FIELDS
-        if isinstance(value := getattr(subscription.condition, name, None), str)
+        value for subscription in subscriptions for _, value in _named_ids(subscription)
     }
     return sorted(ids)
 
@@ -265,11 +290,8 @@ def render_dump(
                 "condition": condition_of(subscription),
                 "logins": {
                     value: logins[value]
-                    for name, _ in _CONDITION_ID_FIELDS
-                    if isinstance(
-                        value := getattr(subscription.condition, name, None), str
-                    )
-                    and value in logins
+                    for _, value in _named_ids(subscription)
+                    if value in logins
                 },
                 "callback_now": subscription.transport.callback,
                 "callback_after": (
@@ -302,8 +324,7 @@ def describe(subscription: Subscription, logins: Mapping[str, str]) -> str:
     """
     named = [
         f"{label} {value}" + (f" = {logins[value]}" if value in logins else "")
-        for name, label in _CONDITION_ID_FIELDS
-        if isinstance(value := getattr(subscription.condition, name, None), str)
+        for label, value in _named_ids(subscription)
     ]
     # A condition naming nobody is not one of the eight, but it still has to be
     # reportable: the id is all Twitch gives that is certain to identify it.


### PR DESCRIPTION
## What was still broken

`condition_of` (#49) stopped Twitch's `""` sentinel — the unset half of a `channel.raid` condition — from reaching the **recreate**. Two other functions read the same condition fields independently and never got that fix, because each had its own copy of the same `getattr` loop over `_CONDITION_ID_FIELDS`:

- **`_condition_ids`** fed `""` into the login lookup, producing a real, reproducible false positive on every dry run against a deployment with any `channel.raid` subscription:
  > `1 subscription condition value(s) cannot be a Twitch user id, so they were left out of the login lookup: ''.`

  It isn't a malformed value — it's Twitch saying "not set," reported as if it were junk.

- **`describe`** printed `"to broadcaster "` with nothing after the space for the same pair, since the incoming and outgoing raid conditions each carry one real id and one `""`.

Both are the identical root cause as the raid-recreate bug fixed in #49, just not yet plugged at their own call sites.

## The fix

Extracted `_named_ids(subscription)` as the one place that reads `_CONDITION_ID_FIELDS` off a live condition and drops `""`. `_condition_ids`, `describe`, and `render_dump`'s per-subscription logins map all go through it now. There's no second copy left to diverge from, so this specific bug can't recur a fourth time by someone forgetting the check.

## Verification

Verified against the exact incoming/outgoing raid pair from a real 97-subscription production dump — absent from the id set, absent from `describe`'s output, no false notice, and absent from the rendered dump's `logins` and `condition`:

```
_condition_ids      -> ['422325043']
describe(incoming)  -> channel.raid (to broadcaster 422325043 = valinmalach)
describe(outgoing)  -> channel.raid (from broadcaster 422325043 = valinmalach)
```

Added that pair as a permanent regression case in the migration test harness (`raid_empty_half_cases`). Two existing harness assertions had been written against the *old* behavior — one expected `""` to still reach `_usable()`'s rejection point, another expected two unusable-value notices where correct behavior now produces one — both updated to assert the improved guarantee instead.

All four repo checks (sourcery fix/check, ruff format/check, pyright) pass clean. `verity analyze` on the staged change: **PASS**, quality 8.3, security 10/10. The one noted risk (a new Twitch condition field needing to be added to `_CONDITION_ID_FIELDS`) is pre-existing and already documented on that constant — not introduced or worsened by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ignore unset Twitch raid condition values consistently across migration lookups, descriptions, and rendered output.

Bug Fixes:
- Prevent empty Twitch raid condition values from generating false login-lookup warnings or blank broadcaster descriptions.
- Keep unset condition halves out of rendered subscription login and condition data.

Enhancements:
- Centralize extraction of named condition IDs so all condition consumers consistently ignore unset values.

Tests:
- Add regression coverage for incoming and outgoing raid conditions with an empty half and update related migration expectations.