### PR TITLE
Log as structured JSON so Railway reads the level instead of the stream

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -74,3 +74,6 @@ rules:
   paths:
     exclude:
     - services/config.py
+    # The pattern is purely syntactic and can't tell logging.Formatter.format(record)
+    # apart from str.format on database text -- logging_json's own self-check calls it.
+    - logging_json.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,15 @@ responses and EventSub payloads. `db/models/` is SQLModel: the tables.
 - **Text from the database is formatted with `safe_format`**, never bare `str.format`
   — a row is not source, and one unmatched brace should not lose the whole message.
   `config.render` additionally resolves `{channel:key}` and `{role:key}`.
+- **Every line either process emits is JSON, through `logging_json.JsonFormatter`.**
+  Railway colors a line by which stream it landed on unless the line itself
+  parses as JSON with a `level` key — `main.py` points the root logger's one
+  handler at stdout through it, and `alembic.ini` does the same for the
+  migration process, which never sees `main.py`'s setup. `extra={...}` on a
+  call becomes a queryable top-level key. Nothing may call
+  `logging.basicConfig` a second time, install a further handler, or `print`/
+  write to stdout or stderr directly — any of those is a line Railway
+  mis-levels by the stream it came in on.
 - **A new cog needs an entry in `constants.COGS`.** Nothing auto-discovers.
 - **Comments record a non-obvious *why*, or do not exist.** Match the density in
   `db/base.py` and `db/config.py`; do not narrate what the code already says.

--- a/alembic.ini
+++ b/alembic.ini
@@ -38,10 +38,9 @@ qualname = alembic
 
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
+args = (sys.stdout,)
 level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S
+class = logging_json.JsonFormatter

--- a/errors.py
+++ b/errors.py
@@ -49,8 +49,8 @@ _MAX_TRACKED = 512
 _undelivered = 0
 
 # Every log line below carries text relayed from Twitch, Discord or the
-# database, so all of them use %r: a newline in a relayed message would
-# otherwise forge a log line. The traceback is the exception, and stays %s.
+# database, so all of them use %r: it shows where a value carries whitespace
+# or quoting that a plain %s would hide.
 
 
 @dataclass
@@ -121,7 +121,7 @@ async def report(exc: Exception, context: str, *, key: str | None = None) -> Non
         # asyncio.gather(return_exceptions=True) is not the one being handled,
         # and format_exc would describe nothing.
         trace = "".join(traceback.format_exception(exc))
-        logger.error("%r\nTraceback:\n%s", summary, trace)
+        logger.error("%r", summary, exc_info=exc)
         # Context names the thing that failed; the type keeps two different
         # failures reported from one place from standing in for each other.
         await _send_once(

--- a/logging_json.py
+++ b/logging_json.py
@@ -46,18 +46,26 @@ class JsonFormatter(logging.Formatter):
             # default=str: a value this can't serialise must not lose the
             # line to "--- Logging error ---" on stderr.
             return json.dumps(payload, default=str)
-        except ValueError:
-            # default=str only covers a type json.dumps doesn't recognise; a
-            # circular extra= value is a dict/list it does recognise, and
-            # fails its own cycle check before default ever runs. The three
-            # fields above are always plain strings, so this retry can't fail
-            # the same way.
+        except (ValueError, TypeError) as exc:
+            # default=str only covers a type json.dumps doesn't recognise.
+            # ValueError is a circular extra= value: a dict/list it does
+            # recognise, so it fails its own cycle check before default ever
+            # runs. TypeError is a dict key inside an extra= value that isn't
+            # str/int/float/bool/None -- an Enum member, a tuple -- which
+            # default never sees either, since it's not the value being
+            # rejected. The three fields above are always plain strings, so
+            # this retry can't fail the same way.
+            #
+            # as exc, used below: ruff format strips the parens from a bare
+            # `except (A, B):`, which then reads exactly like the removed
+            # Python 2 except-binding syntax. Naming the exception makes that
+            # form ambiguous with the old one, so ruff leaves the parens alone.
             return json.dumps(
                 {
                     "level": payload["level"],
                     "message": payload["message"],
                     "logger": payload["logger"],
-                    "formatter_error": "an extra field was not JSON-serialisable",
+                    "formatter_error": f"an extra field was not JSON-serialisable: {exc}",
                 }
             )
 
@@ -147,6 +155,24 @@ def _demo() -> None:
             (),
             None,
             extra={"loop": circular},
+        )
+    )
+    assert payload["level"] == "info"
+    assert payload["message"] == "arrived"
+    assert "formatter_error" in payload
+
+    # A non-primitive dict key in an extra= value raises TypeError, not
+    # ValueError -- must not lose the line either.
+    payload = rendered(
+        logger.makeRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "arrived",
+            (),
+            None,
+            extra={"bad": {("a", "b"): 1}},
         )
     )
     assert payload["level"] == "info"

--- a/logging_json.py
+++ b/logging_json.py
@@ -1,0 +1,100 @@
+"""Structured JSON logging so Railway reads the level instead of the stream.
+
+Railway colors a line by which stream it landed on unless the line itself
+parses as a single-line JSON object carrying a ``level`` key -- see
+docs.railway.com/guides/logs. This formatter is that object. ``main.py``
+points the root logger's handler at it and at stdout; ``alembic.ini`` does the
+same for the migration process, which never sees ``main.py``'s setup.
+"""
+
+import json
+import logging
+
+# Railway's own level words; WARNING and CRITICAL have no exact match there.
+_LEVELS = {"WARNING": "warn", "CRITICAL": "error"}
+
+# Every attribute a LogRecord carries regardless of call site. Read off a real
+# instance rather than listed by hand, so a stdlib version that adds one (as
+# 3.12 did with taskName) does not silently turn into a spurious extra field.
+_RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | {
+    "message",
+    "asctime",
+}
+
+
+class JsonFormatter(logging.Formatter):
+    """One JSON object per line: level, message, logger, and any extra=."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "level": _LEVELS.get(record.levelname, record.levelname.lower()),
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        payload |= ((k, v) for k, v in record.__dict__.items() if k not in _RESERVED)
+        # default=str: a value this can't serialise must not lose the line to
+        # "--- Logging error ---" on stderr.
+        return json.dumps(payload, default=str)
+
+
+def _demo() -> None:
+    logger = logging.getLogger("logging_json.demo")
+    fmt = JsonFormatter()
+
+    def rendered(record: logging.LogRecord) -> dict[str, object]:
+        text = fmt.format(record)
+        assert "\n" not in text, "a formatted line must never split in two"
+        return json.loads(text)
+
+    payload = rendered(
+        logger.makeRecord("x", logging.WARNING, __file__, 1, "one\ntwo", (), None)
+    )
+    assert payload["level"] == "warn"
+    assert payload["message"] == "one\ntwo"
+
+    payload = rendered(
+        logger.makeRecord("x", logging.CRITICAL, __file__, 1, "boom", (), None)
+    )
+    assert payload["level"] == "error"
+
+    try:
+        raise ValueError("bad")
+    except ValueError as exc:
+        record = logger.makeRecord(
+            "x",
+            logging.ERROR,
+            __file__,
+            1,
+            "failed",
+            (),
+            (type(exc), exc, exc.__traceback__),
+        )
+    payload = rendered(record)
+    assert payload["level"] == "error"
+    exception = payload["exception"]
+    assert isinstance(exception, str) and "ValueError" in exception
+
+    class _Unserialisable:
+        def __str__(self) -> str:
+            return "<thing>"
+
+    payload = rendered(
+        logger.makeRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "arrived",
+            (),
+            None,
+            extra={"payload": _Unserialisable(), "broadcaster_id": 123},
+        )
+    )
+    assert payload["payload"] == "<thing>"
+    assert payload["broadcaster_id"] == 123
+
+
+if __name__ == "__main__":
+    _demo()

--- a/logging_json.py
+++ b/logging_json.py
@@ -33,10 +33,33 @@ class JsonFormatter(logging.Formatter):
         }
         if record.exc_info:
             payload["exception"] = self.formatException(record.exc_info)
-        payload |= ((k, v) for k, v in record.__dict__.items() if k not in _RESERVED)
-        # default=str: a value this can't serialise must not lose the line to
-        # "--- Logging error ---" on stderr.
-        return json.dumps(payload, default=str)
+        # not in payload: an extra= key named level/message/logger/exception
+        # must not overwrite the field it collides with -- getMessage() and
+        # record.name are always plain strings, so this can only drop an
+        # extra, never the record's own level, text or logger name.
+        payload |= (
+            (k, v)
+            for k, v in record.__dict__.items()
+            if k not in _RESERVED and k not in payload
+        )
+        try:
+            # default=str: a value this can't serialise must not lose the
+            # line to "--- Logging error ---" on stderr.
+            return json.dumps(payload, default=str)
+        except ValueError:
+            # default=str only covers a type json.dumps doesn't recognise; a
+            # circular extra= value is a dict/list it does recognise, and
+            # fails its own cycle check before default ever runs. The three
+            # fields above are always plain strings, so this retry can't fail
+            # the same way.
+            return json.dumps(
+                {
+                    "level": payload["level"],
+                    "message": payload["message"],
+                    "logger": payload["logger"],
+                    "formatter_error": "an extra field was not JSON-serialisable",
+                }
+            )
 
 
 def _demo() -> None:
@@ -94,6 +117,41 @@ def _demo() -> None:
     )
     assert payload["payload"] == "<thing>"
     assert payload["broadcaster_id"] == 123
+
+    # An extra= key must not be able to spoof the level or logger Railway reads.
+    payload = rendered(
+        logger.makeRecord(
+            "x",
+            logging.ERROR,
+            __file__,
+            1,
+            "bad thing happened",
+            (),
+            None,
+            extra={"level": "debug", "logger": "spoofed"},
+        )
+    )
+    assert payload["level"] == "error"
+    assert payload["logger"] == "x"
+
+    # A circular extra= value must not lose the line to a raised ValueError.
+    circular: dict[str, object] = {}
+    circular["self"] = circular
+    payload = rendered(
+        logger.makeRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "arrived",
+            (),
+            None,
+            extra={"loop": circular},
+        )
+    )
+    assert payload["level"] == "info"
+    assert payload["message"] == "arrived"
+    assert "formatter_error" in payload
 
 
 if __name__ == "__main__":

--- a/logging_json.py
+++ b/logging_json.py
@@ -46,26 +46,26 @@ class JsonFormatter(logging.Formatter):
             # default=str: a value this can't serialise must not lose the
             # line to "--- Logging error ---" on stderr.
             return json.dumps(payload, default=str)
-        except (ValueError, TypeError) as exc:
+        except Exception as exc:  # noqa: BLE001
             # default=str only covers a type json.dumps doesn't recognise.
-            # ValueError is a circular extra= value: a dict/list it does
-            # recognise, so it fails its own cycle check before default ever
-            # runs. TypeError is a dict key inside an extra= value that isn't
-            # str/int/float/bool/None -- an Enum member, a tuple -- which
-            # default never sees either, since it's not the value being
-            # rejected. The three fields above are always plain strings, so
-            # this retry can't fail the same way.
-            #
-            # as exc, used below: ruff format strips the parens from a bare
-            # `except (A, B):`, which then reads exactly like the removed
-            # Python 2 except-binding syntax. Naming the exception makes that
-            # form ambiguous with the old one, so ruff leaves the parens alone.
+            # A circular extra= value raises ValueError, and a non-primitive
+            # dict key (an Enum member, a tuple) raises TypeError -- neither
+            # reaches default, since it's not the value being rejected. Naming
+            # only those two stopped being enough the moment default=str calls
+            # an extra= value's own __str__: that call can raise anything, so
+            # this has to be Exception, not an enumerable list of types. The
+            # three fields above are always plain strings, so this retry can't
+            # fail the same way.
             return json.dumps(
                 {
                     "level": payload["level"],
                     "message": payload["message"],
                     "logger": payload["logger"],
-                    "formatter_error": f"an extra field was not JSON-serialisable: {exc}",
+                    # type(exc).__name__, not str(exc): a class attribute
+                    # lookup can't call a broken __str__ the way interpolating
+                    # exc itself could -- including on exc's own class, if
+                    # that's what a hostile extra= value chose to raise.
+                    "formatter_error": f"an extra field was not JSON-serialisable ({type(exc).__name__})",
                 }
             )
 
@@ -173,6 +173,28 @@ def _demo() -> None:
             (),
             None,
             extra={"bad": {("a", "b"): 1}},
+        )
+    )
+    assert payload["level"] == "info"
+    assert payload["message"] == "arrived"
+    assert "formatter_error" in payload
+
+    # default=str calling a broken __str__ can raise anything -- not just
+    # ValueError/TypeError -- and must not lose the line either.
+    class _BrokenStr:
+        def __str__(self) -> str:
+            raise RuntimeError("str is broken too")
+
+    payload = rendered(
+        logger.makeRecord(
+            "x",
+            logging.INFO,
+            __file__,
+            1,
+            "arrived",
+            (),
+            None,
+            extra={"bad": _BrokenStr()},
         )
     )
     assert payload["level"] == "info"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -12,15 +13,15 @@ from constants import COGS
 from controller import twitch_oauth_router, twitch_router
 from errors import report
 from init import bot
+from logging_json import JsonFormatter
 from services import http_client
 
-# The level and the logger name are in the line rather than in a handler's
-# columns: these are read in Railway's log viewer, which renders neither.
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
-    datefmt="%H:%M:%S",
-)
+# Railway colors a line by which stream it landed on, not by what Python
+# attached to it -- unless the line is JSON with a "level" key, which the
+# viewer decodes into its own level and searchable fields instead.
+_handler = logging.StreamHandler(sys.stdout)
+_handler.setFormatter(JsonFormatter())
+logging.basicConfig(level=logging.INFO, handlers=[_handler])
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 

--- a/uv.lock
+++ b/uv.lock
@@ -841,11 +841,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.3"
+version = "2026.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/31/3d74fa778a63b98b7374323befcc0be5ab3bd94afd4096a0124e7379152c/tzdata-2026.4.tar.gz", hash = "sha256:f1b8bd365d8d210c55353f4d7f8d6d8561c0ba50d704b700d195a9424bba0d79", size = 199350, upload-time = "2026-09-12T12:56:03.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/8737e8d54cf51106118039b83f485a4783112fab49ea9d044b234978a46e/tzdata-2026.4-py2.py3-none-any.whl", hash = "sha256:c2169a8b0a7a5e9674da5a135ccdfb2b3e671b333ed9fed17b41f73c34476e81", size = 347494, upload-time = "2026-09-12T12:56:01.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Railway colors a log line by the stream it lands on (stdout/stderr), not by what Python attached to it — so with `logging.basicConfig`'s default `StreamHandler` (stderr), every line came out red regardless of level.
- Adds `logging_json.JsonFormatter`, a stdlib-only `logging.Formatter` subclass that renders each record as a single-line JSON object (`level`, `message`, `logger`, an `exception` key when present, and any `extra=` key as a top-level attribute), mapping `WARNING`→`warn` and `CRITICAL`→`error` to match Railway's vocabulary.
- Points both processes at it and at stdout: `main.py`'s root logger, and `alembic.ini`'s console handler (alembic runs as a separate process before the app starts and never sees `main.py`'s setup).
- `errors.py.report()` now passes `exc_info=exc` instead of concatenating the traceback into the message string, so it gets its own JSON key instead of splitting the line; corrected a comment there and in `main.py` that no longer matched why the code does what it does.
- Documents the convention in `AGENTS.md` so nothing installs a second handler or writes to stdout/stderr directly in the future.
- No new dependency — `json`/`logging` only, per the issue's explicit call-out of `c0024c9` ("Log without rich").

Closes #44.

## Verification

- `logging_json.py` carries an assert-based self-check (`python logging_json.py`) covering: level mapping including `CRITICAL`→`error`; an embedded newline and a full traceback both staying on one JSON line; an unserialisable `extra=` value surviving via `default=str`; and an `extra=` key reaching the top level.
- Confirmed manually: `alembic upgrade head --sql` now prints single-line JSON on stdout; importing `main.py` and logging at each level produces correctly-mapped single-line JSON; `errors.report()` still builds the Discord traceback attachment unchanged.
- All four required checks (`sourcery review --fix`/`--check`, `ruff format`, `ruff check`, `pyright`) pass clean, and `verity analyze` gated each commit before it was made.
- Not verified: Railway's viewer actually rendering an info line as non-red and `@`-filtering on an `extra=` attribute — the issue itself notes this can only be confirmed after a real deploy.

## Test plan

- [ ] Deploy to Railway and confirm an INFO line renders non-red in the log viewer
- [ ] Confirm `@`-filtering on an `extra=` attribute works in Railway's viewer
- [ ] Confirm alembic's migration output also appears as JSON on a real deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Emit all application and migration logs as resilient structured JSON so Railway can classify levels and expose log metadata correctly.

New Features:
- Add structured, single-line JSON logging with Railway-compatible level names, exception data, logger metadata, and queryable extra fields.

Bug Fixes:
- Ensure application, Alembic, and reported exception logs are emitted on stdout in a format Railway can correctly classify instead of coloring all stderr output as errors.

Enhancements:
- Document the repository-wide logging convention and prevent additional handlers or direct writes to process output streams.

Documentation:
- Document the JSON logging requirements and Railway log handling expectations in AGENTS.md.

Tests:
- Add an assert-based formatter self-check covering level mapping, multiline messages and tracebacks, extra fields, serialization failures, and collision protection.